### PR TITLE
[Feature] Add a basic line chart - pt2: Adding tooltips using the HoverLayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `<HoverLayer>` to reuse the hovering interactions logic across different graphs. (#3)
+- Add the tooltip and hovered effects in `<LineChart>`. (#3)
+- Add the hovering information in `<DataLayer>`. (#3)
+- Add `getSelectorsByField` in `<DataLayer>` to select and convert the data value in a record. (#3)
 - Add a simple `<LineChart>`. (#2)
 - Add `<DataLayer>` to reuse the data calculations (such as domain and range computations) logic. (#2)
 - Add `<AxisLayer>` to reuse the axes on the charts. (#2)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/memoize-one": "^4.1.0",
     "@types/react": "^16.7.18",
     "@types/react-dom": "^16.0.11",
+    "@types/styled-components": "^4.1.6",
     "docz": "^0.13.7",
     "docz-theme-default": "^0.13.7",
     "lerna": "^3.8.0",
@@ -28,6 +29,7 @@
     "tslint-config-airbnb": "^5.11.1",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.2.4"
+    "typescript": "^3.2.4",
+    "styled-components": "^4.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,11 +25,12 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "rimraf": "^2.6.3",
+    "styled-components": "^4.1.3",
+    "react-spring": "^7.2.10",
     "tslint": "^5.12.0",
     "tslint-config-airbnb": "^5.11.1",
     "tslint-eslint-rules": "^5.4.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.2.4",
-    "styled-components": "^4.1.3"
+    "typescript": "^3.2.4"
   }
 }

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -7,12 +7,10 @@ import {
   HoverLayer,
   DataField,
   ResponsiveLayer,
+  TooltipLayer,
   ResponsiveState,
   Scale,
   Margin,
-  Tooltip,
-  TooltipItem,
-  FieldSelector,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
@@ -27,36 +25,6 @@ export interface LineChartProps {
   showLeftAxis: boolean;
   /** Should show the axis on the bottom or not */
   showBottomAxis: boolean;
-}
-
-/** Generates the tooltip box of the line chart */
-function getTooltipBox(
-  hovering: DataLayerRenderParams['hovering'],
-  hoveredPoint: DataLayerRenderParams['hoveredPoint'],
-  data: object[],
-  graphWidth: number,
-  graphHeight: number,
-  margin: Margin,
-  xSelector: FieldSelector,
-  ySelector: FieldSelector,
-) {
-  const { index, position } = hoveredPoint;
-  return (
-    <Tooltip
-      graphWidth={graphWidth}
-      graphHeight={graphHeight}
-      graphMargin={margin}
-      position={{
-        x: xSelector.getScaledVal(data[index]),
-        y: position.y,
-      }}
-      show={hovering}
-    >
-      <h3>{xSelector.getFormattedStringVal(data[index])}</h3>
-      {/* TODO: unify the way of dealing colors of the fields */}
-      <TooltipItem color="#ff7049" text={ySelector.getFormattedStringVal(data[index])} />
-    </Tooltip>
-  );
 }
 
 /** Add a line and a dot for the point being hovered */
@@ -213,16 +181,16 @@ export const LineChart: React.SFC<LineChartProps> = ({
                   </svg>
 
                   {/* Draw the tooltip */}
-                  {getTooltipBox(
-                    hovering,
-                    hoveredPoint,
-                    data,
-                    graphWidth,
-                    graphHeight,
-                    margin,
-                    xSelector,
-                    ySelector,
-                  )}
+                  <TooltipLayer
+                    hovering={hovering}
+                    hoveredPoint={hoveredPoint}
+                    data={data}
+                    graphWidth={graphWidth}
+                    graphHeight={graphHeight}
+                    margin={margin}
+                    xSelector={xSelector}
+                    ySelector={ySelector}
+                  />
                 </>
               );
             }}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -165,6 +165,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                         collisionComponents={data.map(
                           (dataRow, index) => (
                             <rect
+                              // #TODO: use keys defined in the `<DataLayer>`
                               key={`colli-${index}`}
                               x={
                                 index === 0

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -27,9 +27,18 @@ export interface LineChartProps {
   showBottomAxis: boolean;
 }
 
-/** Add a line and a dot for the point being hovered */
-function getHoveringDotAndLine(xPos: number, yPos: number, height: number) {
-  return (
+/** A line and a dot for the point being hovered */
+const HoveringIndicator: React.FC<{
+  hovering: boolean,
+  xPos: number,
+  yPos: number,
+  height: number,
+}> = ({ hovering, xPos, yPos, height }) => {
+  if (!hovering) {
+    return null;
+  }
+
+  return(
     <>
       <line
         x1={xPos}
@@ -46,7 +55,7 @@ function getHoveringDotAndLine(xPos: number, yPos: number, height: number) {
       />
     </>
   );
-}
+};
 
 export const LineChart: React.SFC<LineChartProps> = ({
   data,
@@ -140,11 +149,12 @@ export const LineChart: React.SFC<LineChartProps> = ({
 
                       {/* Draw dots on the line */}
                       {lineDots}
-                      {hovering && getHoveringDotAndLine(
-                        xSelector.getScaledVal(data[hoveredPoint.index]),
-                        ySelector.getScaledVal(data[hoveredPoint.index]),
-                        graphHeight,
-                      )}
+                      <HoveringIndicator
+                        hovering={hovering}
+                        xPos={xSelector.getScaledVal(data[hoveredPoint.index])}
+                        yPos={ySelector.getScaledVal(data[hoveredPoint.index])}
+                        height={graphHeight}
+                      />
 
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -11,6 +11,7 @@ import {
   ResponsiveState,
   Scale,
   Margin,
+  Tooltip,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
@@ -158,19 +159,13 @@ export const LineChart: React.SFC<LineChartProps> = ({
                   {/* Draw the tooltip */}
                   {
                     (hoveredIndex !== null) && (
-                      <div
-                        style={{
-                          position: 'absolute',
-                          top: hoveredPos.y,
-                          left: hoveredPos.x,
-                          backgroundColor: 'rgba(120,200,100, 0.5)',
-                          whiteSpace: 'nowrap',
-                        }}
+                      <Tooltip
+                        top={hoveredPos.y}
+                        left={hoveredPos.x}
                       >
-                        <table>
-                          Tooltip: {data[hoveredIndex].x}
-                        </table>
-                      </div>
+                        <p>Tooltip: {data[hoveredIndex].x}</p>
+                        <p>Test</p>
+                      </Tooltip>
                     )
                   }
                 </>

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -126,7 +126,9 @@ export const LineChart: React.SFC<LineChartProps> = ({
               setHoveredPosAndIndex,
               clearHovering,
             }: DataLayerRenderParams) => {
+              // currently we only have one variable on the x-axis, so we get field `0`
               const xSelector = xAxis.getSelectorsByField(0);
+              // currently we only have one variable on the y-axis, so we get field `0`
               const ySelector = yAxis.getSelectorsByField(0);
 
               /** Width of the collision detection rectangle */
@@ -203,9 +205,6 @@ export const LineChart: React.SFC<LineChartProps> = ({
                               }
                               height={graphHeight}
                               opacity={0}
-                              fill={'#ff7049'}
-                              stroke="blue"
-                              strokeWidth={3}
                             />
                           ),
                         )}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { LinePath } from '@vx/shape';
 import {
-  AxisConfig,
   AxisLayer,
   DataLayer,
   DataLayerRenderParams,
@@ -12,6 +11,8 @@ import {
   Scale,
   Margin,
   Tooltip,
+  FieldSelector,
+  getRecordFieldSelectors,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
@@ -28,49 +29,12 @@ export interface LineChartProps {
   showBottomAxis: boolean;
 }
 
-/**
- * Returns the data value selectors for a data record
- * using the computed axis configurations including the d3Scale function of the axis
- * @param axis - the axis computed from DataLayer
- * @param fieldIndex - the current index of the field
- */
-function getRecordFieldSelectors(axis: AxisConfig, fieldIndex: number) {
-  const { fields, d3Scale, getValue, scaleConfig } = axis;
-  const fieldName = fields[fieldIndex].name;
-
-  /** Given a record of data, it returns the orginal value of the specified field */
-  const getOriginalVal = (record: object) => getValue(record[fieldName]);
-
-  return {
-    getOriginalVal,
-
-    /**
-     * Given a record of data,
-     * it returns the mapped value (computed by d3 scale function) of the specified field
-     */
-    getScaledVal: (record: object) => d3Scale(getOriginalVal(record)),
-
-    getFormattedStringVal: (record: object) => {
-      const recordValue = getOriginalVal(record);
-
-      if (scaleConfig.type === 'time') {
-        // FIXME: unify the way of formatting datetime
-        return recordValue.toLocaleString();
-      }
-
-      return recordValue;
-    },
-  };
-}
-
-const getSelectorType = (false as true) && getRecordFieldSelectors(undefined, 0);
-
 function getTooltipBox(
-  hoveredIndex: number,
+  hoveredIndex: DataLayerRenderParams['hoveredIndex'],
   hoveredPos: DataLayerRenderParams['hoveredPos'],
   data: object[],
-  xSelector: typeof getSelectorType,
-  ySelector: typeof getSelectorType,
+  xSelector: FieldSelector,
+  ySelector: FieldSelector,
 ) {
   if (hoveredIndex === null || !data) {
     return null;

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -12,7 +12,6 @@ import {
   Margin,
   Tooltip,
   FieldSelector,
-  getRecordFieldSelectors,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
@@ -98,8 +97,8 @@ export const LineChart: React.SFC<LineChartProps> = ({
               setHoveredPosAndIndex,
               clearHovering,
             }: DataLayerRenderParams) => {
-              const xSelector = getRecordFieldSelectors(xAxis, 0);
-              const ySelector = getRecordFieldSelectors(yAxis, 0);
+              const xSelector = xAxis.getSelectorsByField(0);
+              const ySelector = yAxis.getSelectorsByField(0);
 
               /** Width of the collision detection rectangle */
               const bandWidth = graphWidth / (data.length - 1);

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -4,9 +4,8 @@ import {
   AxisConfig,
   AxisLayer,
   DataLayer,
-  DataLayerAxes,
+  DataLayerRenderParams,
   HoverLayer,
-  HoverLayerState,
   DataField,
   ResponsiveLayer,
   ResponsiveState,
@@ -67,91 +66,99 @@ export const LineChart: React.SFC<LineChartProps> = ({
         }
 
         return (
-            <DataLayer
-              width={graphWidth}
-              height={graphHeight}
-              data={data}
-              scaleX={scaleX}
-              scaleY={scaleY}
-              fieldsX={fieldsX}
-              fieldsY={fieldsY}
-            >
-              {({ xAxis, yAxis }: DataLayerAxes) => {
-                const getX = getConvertFuncFromAxis(xAxis, 0);
-                const getY = getConvertFuncFromAxis(yAxis, 0);
+          <DataLayer
+            width={graphWidth}
+            height={graphHeight}
+            data={data}
+            scaleX={scaleX}
+            scaleY={scaleY}
+            fieldsX={fieldsX}
+            fieldsY={fieldsY}
+          >
+            {({
+              // computed x and y axis configurations
+              xAxis,
+              yAxis,
+              // currently hovered positions
+              hoveredIndex,
+              hoveredPos,
+              setHoveredPosAndIndex,
+            }: DataLayerRenderParams) => {
+              const getX = getConvertFuncFromAxis(xAxis, 0);
+              const getY = getConvertFuncFromAxis(yAxis, 0);
 
-                /** Width of the collision detection rectangle */
-                const bandWidth = graphWidth / (data.length - 1);
+              /** Width of the collision detection rectangle */
+              const bandWidth = graphWidth / (data.length - 1);
 
-                const lineDots = data.map((dataRow, index) => (
-                  <circle
-                    key={`c-${index}`}
-                    cx={getX(dataRow)}
-                    cy={getY(dataRow)}
-                    r={3.5}
-                    fill={'#ff7049'}
-                  />
-                ));
+              const lineDots = data.map((dataRow, index) => (
+                <circle
+                  key={`c-${index}`}
+                  cx={getX(dataRow)}
+                  cy={getY(dataRow)}
+                  r={3.5}
+                  fill={'#ff7049'}
+                />
+              ));
 
-                return (
-                  <>
-                    <svg width={outerWidth} height={outerHeight}>
-                      <g transform={`translate(${left}, ${top})`}>
-                        {/* Draw the axes */}
-                        <AxisLayer
-                          width={graphWidth}
-                          height={graphHeight}
-                          showLeftAxis={showLeftAxis}
-                          showBottomAxis={showBottomAxis}
-                          data={data}
-                          xAxis={xAxis}
-                          yAxis={yAxis}
-                        />
+              return (
+                <>
+                  <svg width={outerWidth} height={outerHeight}>
+                    <g transform={`translate(${left}, ${top})`}>
+                      {/* Draw the axes */}
+                      <AxisLayer
+                        width={graphWidth}
+                        height={graphHeight}
+                        showLeftAxis={showLeftAxis}
+                        showBottomAxis={showBottomAxis}
+                        data={data}
+                        xAxis={xAxis}
+                        yAxis={yAxis}
+                      />
 
-                        {/* Draw the line */}
-                        <LinePath
-                          data={data}
-                          x={getX}
-                          y={getY}
-                          stroke={'#ff7049'}
-                          strokeWidth={2}
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        />
+                      {/* Draw the line */}
+                      <LinePath
+                        data={data}
+                        x={getX}
+                        y={getY}
+                        stroke={'#ff7049'}
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
 
-                        {/* Draw dots on the line */}
-                        {lineDots}
+                      {/* Draw dots on the line */}
+                      {lineDots}
 
-                        {/* Areas which are used to detect mouse or touch interactions */}
-                        <HoverLayer
-                          width={outerWidth}
-                          height={outerWidth}
-                          margin={margin}
-                          collisionComponents={
-                            data.map((dataRow, index) => (
-                              <rect
-                                key={`colli-${index}`}
-                                x={index === 0 ? 0 : getX(dataRow) - bandWidth * 0.5}
-                                y={0}
-                                width={index === 0 || index === data.length - 1
-                                  ? bandWidth / 2
-                                  : bandWidth
-                                }
-                                height={graphHeight}
-                                fill={'#ff7049'}
-                                opacity={0.5}
-                                stroke="blue"
-                                strokeWidth={3}
-                              />
-                            ))
-                          }
-                        />
-                      </g>
-                    </svg>
-                  </>
-                );
-              }}
-            </DataLayer>
+                      {/* Areas which are used to detect mouse or touch interactions */}
+                      <HoverLayer
+                        setHoveredPosAndIndex={setHoveredPosAndIndex}
+                        margin={margin}
+                        collisionComponents={data.map((dataRow, index) => (
+                          <rect
+                            key={`colli-${index}`}
+                            x={
+                              index === 0 ? 0 : getX(dataRow) - bandWidth * 0.5
+                            }
+                            y={0}
+                            width={
+                              index === 0 || index === data.length - 1
+                                ? bandWidth / 2
+                                : bandWidth
+                            }
+                            height={graphHeight}
+                            fill={'#ff7049'}
+                            opacity={0.5}
+                            stroke="blue"
+                            strokeWidth={3}
+                          />
+                        ))}
+                      />
+                    </g>
+                  </svg>
+                </>
+              );
+            }}
+          </DataLayer>
         );
       }}
     </ResponsiveLayer>

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -158,17 +158,18 @@ export const LineChart: React.SFC<LineChartProps> = ({
                   {/* Draw the tooltip */}
                   {
                     (hoveredIndex !== null) && (
-                      <div>
-                        <div
-                          style={{
-                            position: 'absolute',
-                            top: hoveredPos.y,
-                            left: hoveredPos.x,
-                            backgroundColor: 'rgba(200,200,100, 0.5)',
-                          }}
-                        >
+                      <div
+                        style={{
+                          position: 'absolute',
+                          top: hoveredPos.y,
+                          left: hoveredPos.x,
+                          backgroundColor: 'rgba(120,200,100, 0.5)',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        <table>
                           Tooltip: {data[hoveredIndex].x}
-                        </div>
+                        </table>
                       </div>
                     )
                   }

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -29,6 +29,7 @@ export interface LineChartProps {
   showBottomAxis: boolean;
 }
 
+/** Generates the tooltip box of the line chart */
 function getTooltipBox(
   hovering: DataLayerRenderParams['hovering'],
   hoveredPoint: DataLayerRenderParams['hoveredPoint'],
@@ -55,6 +56,27 @@ function getTooltipBox(
       {/* TODO: unify the way of dealing colors of the fields */}
       <TooltipItem color="#ff7049" text={ySelector.getFormattedStringVal(data[index])} />
     </Tooltip>
+  );
+}
+
+/** Add a line and a dot for the point being hovered */
+function getHoveringDotAndLine(xPos: number, yPos: number, height: number) {
+  return (
+    <>
+      <line
+        x1={xPos}
+        y1={0}
+        x2={xPos}
+        y2={height}
+        style={{ stroke:'rgba(124, 137, 147, 0.25)', strokeWidth: 2 }}
+      />
+      <circle
+        cx={xPos}
+        cy={yPos}
+        r={4.5}
+        fill={'#ff7049'}
+      />
+    </>
   );
 }
 
@@ -120,15 +142,6 @@ export const LineChart: React.SFC<LineChartProps> = ({
                 />
               ));
 
-              const hoveringDot = hovering && (
-                <circle
-                  cx={xSelector.getScaledVal(data[hoveredPoint.index])}
-                  cy={ySelector.getScaledVal(data[hoveredPoint.index])}
-                  r={4.5}
-                  fill={'#ff7049'}
-                />
-              );
-
               return (
                 <>
                   <svg width={outerWidth} height={outerHeight}>
@@ -157,7 +170,11 @@ export const LineChart: React.SFC<LineChartProps> = ({
 
                       {/* Draw dots on the line */}
                       {lineDots}
-                      {hoveringDot}
+                      {hovering && getHoveringDotAndLine(
+                        xSelector.getScaledVal(data[hoveredPoint.index]),
+                        ySelector.getScaledVal(data[hoveredPoint.index]),
+                        graphHeight,
+                      )}
 
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -11,6 +11,7 @@ import {
   Scale,
   Margin,
   Tooltip,
+  TooltipItem,
   FieldSelector,
 } from '@ichef/transcharts-graph';
 
@@ -50,8 +51,9 @@ function getTooltipBox(
       }}
       show={hovering}
     >
-      <p>{xSelector.getFormattedStringVal(data[index])}</p>
-      <p>{ySelector.getFormattedStringVal(data[index])}</p>
+      <h3>{xSelector.getFormattedStringVal(data[index])}</h3>
+      {/* TODO: unify the way of dealing colors of the fields */}
+      <TooltipItem color="#ff7049" text={ySelector.getFormattedStringVal(data[index])} />
     </Tooltip>
   );
 }
@@ -183,8 +185,8 @@ export const LineChart: React.SFC<LineChartProps> = ({
                                   : bandWidth
                               }
                               height={graphHeight}
+                              opacity={0}
                               fill={'#ff7049'}
-                              opacity={0.5}
                               stroke="blue"
                               strokeWidth={3}
                             />

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -31,23 +31,23 @@ export interface LineChartProps {
 
 function getTooltipBox(
   hovering: DataLayerRenderParams['hovering'],
-  hoveredIndex: DataLayerRenderParams['hoveredIndex'],
-  hoveredPos: DataLayerRenderParams['hoveredPos'],
+  hoveredPoint: DataLayerRenderParams['hoveredPoint'],
   data: object[],
   graphWidth: number,
   graphHeight: number,
   xSelector: FieldSelector,
   ySelector: FieldSelector,
 ) {
+  const { index, position } = hoveredPoint;
   return (
     <Tooltip
       graphWidth={graphWidth}
       graphHeight={graphHeight}
-      position={hoveredPos}
+      position={position}
       show={hovering}
     >
-      <p>{xSelector.getFormattedStringVal(data[hoveredIndex])}</p>
-      <p>{ySelector.getFormattedStringVal(data[hoveredIndex])}</p>
+      <p>{xSelector.getFormattedStringVal(data[index])}</p>
+      <p>{ySelector.getFormattedStringVal(data[index])}</p>
     </Tooltip>
   );
 }
@@ -94,8 +94,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
               yAxis,
               // currently hovered positions
               hovering,
-              hoveredIndex,
-              hoveredPos,
+              hoveredPoint,
               setHoveredPosAndIndex,
               clearHovering,
             }: DataLayerRenderParams) => {
@@ -158,7 +157,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                                 index === 0
                                   ? 0
                                   : xSelector.getScaledVal(
-                                      dataRow
+                                      dataRow,
                                     ) -
                                     bandWidth * 0.5
                               }
@@ -175,7 +174,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                               stroke="blue"
                               strokeWidth={3}
                             />
-                          )
+                          ),
                         )}
                       />
                     </g>
@@ -184,8 +183,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                   {/* Draw the tooltip */}
                   {getTooltipBox(
                     hovering,
-                    hoveredIndex,
-                    hoveredPos,
+                    hoveredPoint,
                     data,
                     graphWidth,
                     graphHeight,

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -34,6 +34,7 @@ function getTooltipBox(
   data: object[],
   graphWidth: number,
   graphHeight: number,
+  margin: Margin,
   xSelector: FieldSelector,
   ySelector: FieldSelector,
 ) {
@@ -42,7 +43,11 @@ function getTooltipBox(
     <Tooltip
       graphWidth={graphWidth}
       graphHeight={graphHeight}
-      position={position}
+      graphMargin={margin}
+      position={{
+        x: xSelector.getScaledVal(data[index]),
+        y: position.y,
+      }}
       show={hovering}
     >
       <p>{xSelector.getFormattedStringVal(data[index])}</p>
@@ -113,6 +118,15 @@ export const LineChart: React.SFC<LineChartProps> = ({
                 />
               ));
 
+              const hoveringDot = hovering && (
+                <circle
+                  cx={xSelector.getScaledVal(data[hoveredPoint.index])}
+                  cy={ySelector.getScaledVal(data[hoveredPoint.index])}
+                  r={4.5}
+                  fill={'#ff7049'}
+                />
+              );
+
               return (
                 <>
                   <svg width={outerWidth} height={outerHeight}>
@@ -141,6 +155,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
 
                       {/* Draw dots on the line */}
                       {lineDots}
+                      {hoveringDot}
 
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
@@ -186,6 +201,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                     data,
                     graphWidth,
                     graphHeight,
+                    margin,
                     xSelector,
                     ySelector,
                   )}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -34,11 +34,15 @@ function getTooltipBox(
   hoveredIndex: DataLayerRenderParams['hoveredIndex'],
   hoveredPos: DataLayerRenderParams['hoveredPos'],
   data: object[],
+  graphWidth: number,
+  graphHeight: number,
   xSelector: FieldSelector,
   ySelector: FieldSelector,
 ) {
   return (
     <Tooltip
+      graphWidth={graphWidth}
+      graphHeight={graphHeight}
       position={hoveredPos}
       show={hovering}
     >
@@ -142,33 +146,52 @@ export const LineChart: React.SFC<LineChartProps> = ({
 
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
-                        setHoveredPosAndIndex={setHoveredPosAndIndex}
+                        setHoveredPosAndIndex={
+                          setHoveredPosAndIndex
+                        }
                         clearHovering={clearHovering}
-                        collisionComponents={data.map((dataRow, index) => (
-                          <rect
-                            key={`colli-${index}`}
-                            x={
-                              index === 0 ? 0 : xSelector.getScaledVal(dataRow) - bandWidth * 0.5
-                            }
-                            y={0}
-                            width={
-                              index === 0 || index === data.length - 1
-                                ? bandWidth / 2
-                                : bandWidth
-                            }
-                            height={graphHeight}
-                            fill={'#ff7049'}
-                            opacity={0.5}
-                            stroke="blue"
-                            strokeWidth={3}
-                          />
-                        ))}
+                        collisionComponents={data.map(
+                          (dataRow, index) => (
+                            <rect
+                              key={`colli-${index}`}
+                              x={
+                                index === 0
+                                  ? 0
+                                  : xSelector.getScaledVal(
+                                      dataRow
+                                    ) -
+                                    bandWidth * 0.5
+                              }
+                              y={0}
+                              width={
+                                index === 0 ||
+                                index === data.length - 1
+                                  ? bandWidth / 2
+                                  : bandWidth
+                              }
+                              height={graphHeight}
+                              fill={'#ff7049'}
+                              opacity={0.5}
+                              stroke="blue"
+                              strokeWidth={3}
+                            />
+                          )
+                        )}
                       />
                     </g>
                   </svg>
 
                   {/* Draw the tooltip */}
-                  {getTooltipBox(hovering, hoveredIndex, hoveredPos, data, xSelector, ySelector)}
+                  {getTooltipBox(
+                    hovering,
+                    hoveredIndex,
+                    hoveredPos,
+                    data,
+                    graphWidth,
+                    graphHeight,
+                    xSelector,
+                    ySelector,
+                  )}
                 </>
               );
             }}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -5,19 +5,17 @@ import {
   AxisLayer,
   DataLayer,
   DataLayerAxes,
+  TooltipLayer,
   DataField,
   ResponsiveLayer,
   ResponsiveState,
   Scale,
+  Margin,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
-  margin: {
-    top: number;
-    right: number;
-    bottom: number;
-    left: number;
-  };
+   /** Margin between the inner graph area and the outer svg */
+  margin: Margin;
   data: object[];
   scaleX: Scale;
   scaleY: Scale;
@@ -78,6 +76,9 @@ export const LineChart: React.SFC<LineChartProps> = ({
                 const getX = getConvertFuncFromAxis(xAxis, 0);
                 const getY = getConvertFuncFromAxis(yAxis, 0);
 
+                /** Width of the collision detection rectangle */
+                const bandWidth = graphWidth / (data.length - 1);
+
                 const lineDots = data.map((dataRow, index) => (
                   <circle
                     key={`c-${index}`}
@@ -99,6 +100,23 @@ export const LineChart: React.SFC<LineChartProps> = ({
                       data={data}
                       xAxis={xAxis}
                       yAxis={yAxis}
+                    />
+
+                    <TooltipLayer
+                      margin={margin}
+                      collisionComponents={
+                        data.map((dataRow, index) => (
+                          <rect
+                            key={`colli-${index}`}
+                            x={getX(dataRow) - bandWidth * 0.5}
+                            y={0}
+                            width={bandWidth}
+                            height={graphHeight}
+                            fill={'#ff7049'}
+                            opacity={0.5}
+                          />
+                        ))
+                      }
                     />
 
                     {/* Draw the line */}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -5,7 +5,8 @@ import {
   AxisLayer,
   DataLayer,
   DataLayerAxes,
-  TooltipLayer,
+  HoverLayer,
+  HoverLayerState,
   DataField,
   ResponsiveLayer,
   ResponsiveState,
@@ -66,7 +67,6 @@ export const LineChart: React.SFC<LineChartProps> = ({
         }
 
         return (
-          <svg width={outerWidth} height={outerHeight}>
             <DataLayer
               width={graphWidth}
               height={graphHeight}
@@ -94,58 +94,64 @@ export const LineChart: React.SFC<LineChartProps> = ({
                 ));
 
                 return (
-                  <g transform={`translate(${left}, ${top})`}>
-                    {/* Draw the axes */}
-                    <AxisLayer
-                      width={graphWidth}
-                      height={graphHeight}
-                      showLeftAxis={showLeftAxis}
-                      showBottomAxis={showBottomAxis}
-                      data={data}
-                      xAxis={xAxis}
-                      yAxis={yAxis}
-                    />
+                  <>
+                    <svg width={outerWidth} height={outerHeight}>
+                      <g transform={`translate(${left}, ${top})`}>
+                        {/* Draw the axes */}
+                        <AxisLayer
+                          width={graphWidth}
+                          height={graphHeight}
+                          showLeftAxis={showLeftAxis}
+                          showBottomAxis={showBottomAxis}
+                          data={data}
+                          xAxis={xAxis}
+                          yAxis={yAxis}
+                        />
 
-                    <TooltipLayer
-                      margin={margin}
-                      collisionComponents={
-                        data.map((dataRow, index) => (
-                          <rect
-                            key={`colli-${index}`}
-                            x={index === 0 ? 0 : getX(dataRow) - bandWidth * 0.5}
-                            y={0}
-                            width={index === 0 || index === data.length - 1
-                              ? bandWidth / 2
-                              : bandWidth
-                            }
-                            height={graphHeight}
-                            fill={'#ff7049'}
-                            opacity={0.5}
-                            stroke="blue"
-                            strokeWidth={3}
-                          />
-                        ))
-                      }
-                    />
+                        {/* Draw the line */}
+                        <LinePath
+                          data={data}
+                          x={getX}
+                          y={getY}
+                          stroke={'#ff7049'}
+                          strokeWidth={2}
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        />
 
-                    {/* Draw the line */}
-                    <LinePath
-                      data={data}
-                      x={getX}
-                      y={getY}
-                      stroke={'#ff7049'}
-                      strokeWidth={2}
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
+                        {/* Draw dots on the line */}
+                        {lineDots}
 
-                    {/* Draw dots on the line */}
-                    {lineDots}
-                  </g>
+                        {/* Areas which are used to detect mouse or touch interactions */}
+                        <HoverLayer
+                          width={outerWidth}
+                          height={outerWidth}
+                          margin={margin}
+                          collisionComponents={
+                            data.map((dataRow, index) => (
+                              <rect
+                                key={`colli-${index}`}
+                                x={index === 0 ? 0 : getX(dataRow) - bandWidth * 0.5}
+                                y={0}
+                                width={index === 0 || index === data.length - 1
+                                  ? bandWidth / 2
+                                  : bandWidth
+                                }
+                                height={graphHeight}
+                                fill={'#ff7049'}
+                                opacity={0.5}
+                                stroke="blue"
+                                strokeWidth={3}
+                              />
+                            ))
+                          }
+                        />
+                      </g>
+                    </svg>
+                  </>
                 );
               }}
             </DataLayer>
-          </svg>
         );
       }}
     </ResponsiveLayer>

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -132,7 +132,6 @@ export const LineChart: React.SFC<LineChartProps> = ({
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
                         setHoveredPosAndIndex={setHoveredPosAndIndex}
-                        margin={margin}
                         collisionComponents={data.map((dataRow, index) => (
                           <rect
                             key={`colli-${index}`}
@@ -155,6 +154,24 @@ export const LineChart: React.SFC<LineChartProps> = ({
                       />
                     </g>
                   </svg>
+
+                  {/* Draw the tooltip */}
+                  {
+                    (hoveredIndex !== null) && (
+                      <div>
+                        <div
+                          style={{
+                            position: 'absolute',
+                            top: hoveredPos.y,
+                            left: hoveredPos.x,
+                            backgroundColor: 'rgba(200,200,100, 0.5)',
+                          }}
+                        >
+                          Tooltip: {data[hoveredIndex].x}
+                        </div>
+                      </div>
+                    )
+                  }
                 </>
               );
             }}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -30,19 +30,17 @@ export interface LineChartProps {
 }
 
 function getTooltipBox(
+  hovering: DataLayerRenderParams['hovering'],
   hoveredIndex: DataLayerRenderParams['hoveredIndex'],
   hoveredPos: DataLayerRenderParams['hoveredPos'],
   data: object[],
   xSelector: FieldSelector,
   ySelector: FieldSelector,
 ) {
-  if (hoveredIndex === null || !data) {
-    return null;
-  }
-
   return (
     <Tooltip
       position={hoveredPos}
+      show={hovering}
     >
       <p>{xSelector.getFormattedStringVal(data[hoveredIndex])}</p>
       <p>{ySelector.getFormattedStringVal(data[hoveredIndex])}</p>
@@ -91,10 +89,11 @@ export const LineChart: React.SFC<LineChartProps> = ({
               xAxis,
               yAxis,
               // currently hovered positions
+              hovering,
               hoveredIndex,
               hoveredPos,
               setHoveredPosAndIndex,
-              clearHoveredIndex,
+              clearHovering,
             }: DataLayerRenderParams) => {
               const xSelector = getRecordFieldSelectors(xAxis, 0);
               const ySelector = getRecordFieldSelectors(yAxis, 0);
@@ -144,7 +143,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
                         setHoveredPosAndIndex={setHoveredPosAndIndex}
-                        clearHoveredIndex={clearHoveredIndex}
+                        clearHovering={clearHovering}
                         collisionComponents={data.map((dataRow, index) => (
                           <rect
                             key={`colli-${index}`}
@@ -169,7 +168,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                   </svg>
 
                   {/* Draw the tooltip */}
-                  {getTooltipBox(hoveredIndex, hoveredPos, data, xSelector, ySelector)}
+                  {getTooltipBox(hovering, hoveredIndex, hoveredPos, data, xSelector, ySelector)}
                 </>
               );
             }}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -1,16 +1,22 @@
 import * as React from 'react';
 import { LinePath } from '@vx/shape';
 import {
+  // from AxisLayer
   AxisLayer,
+  // from DataLayer
   DataLayer,
   DataLayerRenderParams,
+  // from HoverLayer
   HoverLayer,
-  DataField,
+  // from ResponsiveLayer
   ResponsiveLayer,
-  TooltipLayer,
   ResponsiveState,
-  Scale,
+  // from TooltipLayer
+  TooltipLayer,
+  // from common types
+  DataField,
   Margin,
+  Scale,
 } from '@ichef/transcharts-graph';
 
 export interface LineChartProps {
@@ -158,35 +164,33 @@ export const LineChart: React.SFC<LineChartProps> = ({
 
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
-                        setHoveredPosAndIndex={
-                          setHoveredPosAndIndex
-                        }
+                        setHoveredPosAndIndex={setHoveredPosAndIndex}
                         clearHovering={clearHovering}
                         collisionComponents={data.map(
-                          (dataRow, index) => (
-                            <rect
-                              // #TODO: use keys defined in the `<DataLayer>`
-                              key={`colli-${index}`}
-                              x={
-                                index === 0
-                                  ? 0
-                                  : xSelector.getScaledVal(
-                                      dataRow,
-                                    ) -
-                                    bandWidth * 0.5
-                              }
-                              y={0}
-                              width={
-                                index === 0 ||
-                                index === data.length - 1
-                                  ? bandWidth / 2
-                                  : bandWidth
-                              }
-                              height={graphHeight}
-                              opacity={0}
-                            />
-                          ),
-                        )}
+                          (dataRow, index) => {
+                            const rectX = index === 0
+                              ? 0
+                              : xSelector.getScaledVal(
+                                  dataRow,
+                                ) -
+                                bandWidth * 0.5;
+
+                            const rectWidth = index === 0 || index === data.length - 1
+                              ? bandWidth / 2
+                              : bandWidth;
+
+                            return (
+                              <rect
+                                // #TODO: use keys defined in the `<DataLayer>`
+                                key={`colli-${index}`}
+                                x={rectX}
+                                y={0}
+                                width={rectWidth}
+                                height={graphHeight}
+                                opacity={0}
+                              />
+                            );
+                          })}
                       />
                     </g>
                   </svg>

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -94,6 +94,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
               hoveredIndex,
               hoveredPos,
               setHoveredPosAndIndex,
+              clearHoveredIndex,
             }: DataLayerRenderParams) => {
               const xSelector = getRecordFieldSelectors(xAxis, 0);
               const ySelector = getRecordFieldSelectors(yAxis, 0);
@@ -143,6 +144,7 @@ export const LineChart: React.SFC<LineChartProps> = ({
                       {/* Areas which are used to detect mouse or touch interactions */}
                       <HoverLayer
                         setHoveredPosAndIndex={setHoveredPosAndIndex}
+                        clearHoveredIndex={clearHoveredIndex}
                         collisionComponents={data.map((dataRow, index) => (
                           <rect
                             key={`colli-${index}`}

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -61,6 +61,10 @@ export const LineChart: React.SFC<LineChartProps> = ({
         const graphWidth = outerWidth - left - right;
         const graphHeight = outerHeight - top - bottom;
 
+        if (graphWidth <= 0 || graphHeight <= 0) {
+          return null;
+        }
+
         return (
           <svg width={outerWidth} height={outerHeight}>
             <DataLayer
@@ -108,12 +112,17 @@ export const LineChart: React.SFC<LineChartProps> = ({
                         data.map((dataRow, index) => (
                           <rect
                             key={`colli-${index}`}
-                            x={getX(dataRow) - bandWidth * 0.5}
+                            x={index === 0 ? 0 : getX(dataRow) - bandWidth * 0.5}
                             y={0}
-                            width={bandWidth}
+                            width={index === 0 || index === data.length - 1
+                              ? bandWidth / 2
+                              : bandWidth
+                            }
                             height={graphHeight}
                             fill={'#ff7049'}
                             opacity={0.5}
+                            stroke="blue"
+                            strokeWidth={3}
                           />
                         ))
                       }

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -34,6 +34,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
+    "react-spring": "^7.2.10",
     "styled-components": "^4.1.3"
   },
   "bugs": {

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -39,6 +39,7 @@
     "url": "https://github.com/iCHEF/transcharts/issues"
   },
   "dependencies": {
+    "@vx/event": "^0.0.182",
     "d3-array": "^2.0.3",
     "d3-scale": "^2.1.2",
     "lodash-es": "^4.17.11",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -33,7 +33,8 @@
   "peerDependencies": {
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react-dom": "^16.7.0",
+    "styled-components": "^4.1.3"
   },
   "bugs": {
     "url": "https://github.com/iCHEF/transcharts/issues"

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -42,6 +42,8 @@ export interface AxisConfig {
 
   /** d3's Scaling function employed in this axis */
   d3Scale: ScalePoint<any> | ScaleTime<any, any> | ScaleLinear<any, any>; // d3 scale function
+
+  scaleConfig: Scale;
 }
 
 export interface Margin {

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -24,6 +24,12 @@ export interface DataField {
   color: string; // TODO: accept a function?: (index, value) => {...}
 }
 
+export interface FieldSelector {
+  getOriginalVal: (record: object) => any;
+  getScaledVal: (record: object) => any;
+  getFormattedStringVal: (record: object) => string;
+}
+
 export interface AxisConfig {
   /**  List of fields appear in this axis */
   fields: DataField[];
@@ -44,6 +50,8 @@ export interface AxisConfig {
   d3Scale: ScalePoint<any> | ScaleTime<any, any> | ScaleLinear<any, any>; // d3 scale function
 
   scaleConfig: Scale;
+
+  getSelectorsByField: (fieldIndex: number) => FieldSelector;
 }
 
 export interface Margin {

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -43,3 +43,10 @@ export interface AxisConfig {
   /** d3's Scaling function employed in this axis */
   d3Scale: ScalePoint<any> | ScaleTime<any, any> | ScaleLinear<any, any>; // d3 scale function
 }
+
+export interface Margin {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+}

--- a/packages/graph/src/context/dataLayerContext.ts
+++ b/packages/graph/src/context/dataLayerContext.ts
@@ -1,8 +1,0 @@
-import { createContext } from 'react';
-
-export interface DataLayerContextInferface {
-  activeDataIndex: number | null;
-  setActiveDataIndex: (activeDataIndex: number) => void;
-}
-
-export default createContext<DataLayerContextInferface | null>(null);

--- a/packages/graph/src/context/dataLayerContext.ts
+++ b/packages/graph/src/context/dataLayerContext.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+
+export interface DataLayerContextInferface {
+  activeDataIndex: number | null;
+  setActiveDataIndex: (activeDataIndex: number) => void;
+}
+
+export default createContext<DataLayerContextInferface | null>(null);

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -4,3 +4,4 @@ export * from './layers/ResponsiveLayer';
 export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
 export * from './layers/HoverLayer';
+export * from './tooltip/Tooltip';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -3,4 +3,4 @@ export * from './common/types';
 export * from './layers/ResponsiveLayer';
 export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
-export * from './layers/TooltipLayer';
+export * from './layers/HoverLayer';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -5,4 +5,5 @@ export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
 export * from './layers/HoverLayer';
 export * from './tooltip/Tooltip';
+export * from './tooltip/TooltipItem';
 export * from './utils/getRecordFieldSelectors';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -4,6 +4,7 @@ export * from './layers/ResponsiveLayer';
 export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
 export * from './layers/HoverLayer';
+export * from './layers/TooltipLayer';
 export * from './tooltip/Tooltip';
 export * from './tooltip/TooltipItem';
 export * from './utils/getRecordFieldSelectors';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -3,3 +3,4 @@ export * from './common/types';
 export * from './layers/ResponsiveLayer';
 export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
+export * from './layers/TooltipLayer';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -5,3 +5,4 @@ export * from './layers/DataLayer';
 export * from './layers/AxisLayer';
 export * from './layers/HoverLayer';
 export * from './tooltip/Tooltip';
+export * from './utils/getRecordFieldSelectors';

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -24,13 +24,15 @@ export interface DataLayerState {
 export interface DataLayerRenderParams extends DataLayerState {
   xAxis: AxisConfig;
   yAxis: AxisConfig;
-  /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
+  /** Function to record hover or touch interactions, which is used by `<HoverLayer>` */
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
 
-  /** Function let `<TouchLayer>` hide the tooltip */
+  /** Function let `<HoverLayer>` hide the tooltip */
   clearHovering: () => void;
 }
 
+// #TODO: separate the data and hovering information,
+// and re-write it using Hooks
 export interface DataLayerProps {
   /** Width of the inner graph */
   width: number;

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -3,7 +3,6 @@ import memoizeOne from 'memoize-one';
 
 import { Scale, DataField, AxisConfig } from '../common/types';
 import { getAxisConfig } from '../utils/getAxisConfig';
-import dataLayerContext, { DataLayerContextInferface } from '../context/dataLayerContext';
 
 export interface DataLayerAxes {
   xAxis: AxisConfig;
@@ -41,14 +40,19 @@ export interface DataLayerProps {
   children: (axes: DataLayerAxes) => React.ReactNode;
 }
 
+export interface DataLayerState {
+  activeDataIndex: number | null;
+  setActiveDataIndex: (activeDataIndex: number) => void;
+}
+
 /**
  * The layer is responsible for computing axis data in order to draw a graph
  */
 export class DataLayer extends React.PureComponent<
   DataLayerProps,
-  DataLayerContextInferface
+  DataLayerState
 > {
-  public state: DataLayerContextInferface = {
+  public state: DataLayerState = {
     activeDataIndex: null,
     setActiveDataIndex: (activeDataIndex: number) => {
       this.setState({ activeDataIndex });
@@ -65,8 +69,6 @@ export class DataLayer extends React.PureComponent<
   );
 
   public render() {
-    const { Provider } = dataLayerContext;
-
     const {
       width,
       height,
@@ -77,6 +79,7 @@ export class DataLayer extends React.PureComponent<
       fieldsY,
       children,
     } = this.props;
+
     const { xAxis, yAxis } = this.getXYAxes(
       width,
       height,
@@ -86,10 +89,7 @@ export class DataLayer extends React.PureComponent<
       fieldsX,
       fieldsY,
     );
-    return (
-      <Provider value={this.state}>
-        {children({ xAxis, yAxis })}
-      </Provider>
-    );
+
+    return children({ xAxis, yAxis });
   }
 }

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -16,6 +16,9 @@ export interface DataLayerState {
 
   /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
+
+  /** Function let `<TouchLayer>` hide the tooltip */
+  clearHoveredIndex: () => void;
 }
 
 export interface DataLayerRenderParams extends DataLayerState {
@@ -64,6 +67,9 @@ export class DataLayer extends React.PureComponent<
   public state: DataLayerState = {
     hoveredIndex: null,
     hoveredPos: null,
+    clearHoveredIndex: () => {
+      this.setState({ hoveredIndex: null });
+    },
     setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => {
       this.setState({
         hoveredIndex,

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -19,17 +19,16 @@ export interface DataLayerState {
       y: number;
     };
   };
-
-  /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
-  setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
-
-  /** Function let `<TouchLayer>` hide the tooltip */
-  clearHovering: () => void;
 }
 
 export interface DataLayerRenderParams extends DataLayerState {
   xAxis: AxisConfig;
   yAxis: AxisConfig;
+  /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
+  setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
+
+  /** Function let `<TouchLayer>` hide the tooltip */
+  clearHovering: () => void;
 }
 
 export interface DataLayerProps {
@@ -79,21 +78,23 @@ export class DataLayer extends React.PureComponent<
         y: 0,
       },
     },
-    clearHovering: () => {
-      this.setState({ hovering: false });
-    },
-    setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => {
-      this.setState({
-        hovering: true,
-        hoveredPoint: {
-          index: hoveredIndex,
-          position: {
-            x: xPos,
-            y: yPos,
-          },
+  };
+
+  public clearHovering = () => {
+    this.setState({ hovering: false });
+  };
+
+  public setHoveredPosAndIndex = (hoveredIndex: number, xPos: number, yPos: number) => {
+    this.setState({
+      hovering: true,
+      hoveredPoint: {
+        index: hoveredIndex,
+        position: {
+          x: xPos,
+          y: yPos,
         },
-      });
-    },
+      },
+    });
   };
 
   private getXYAxes = memoizeOne(
@@ -127,6 +128,12 @@ export class DataLayer extends React.PureComponent<
       fieldsY,
     );
 
-    return children({ xAxis, yAxis, ...this.state });
+    return children({
+      ...this.state,
+      xAxis,
+      yAxis,
+      clearHovering: this.clearHovering,
+      setHoveredPosAndIndex: this.setHoveredPosAndIndex,
+    });
   }
 }

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -15,7 +15,7 @@ export interface DataLayerState {
   hoveredPos: {
     x: number;
     y: number;
-  } | null;
+  };
 
   /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
@@ -70,7 +70,10 @@ export class DataLayer extends React.PureComponent<
   public state: DataLayerState = {
     hovering: false,
     hoveredIndex: 0,
-    hoveredPos: null,
+    hoveredPos: {
+      x: 0,
+      y: 0,
+    },
     clearHovering: () => {
       this.setState({ hovering: false });
     },

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -8,13 +8,16 @@ export interface DataLayerState {
   /** Records whether there is mouse or touch event generating from the inner layer */
   hovering: boolean;
 
-  /** The index of data being hovered or touched */
-  hoveredIndex: number;
+  /** The position of the point being hovered and its mapped index of data  */
+  hoveredPoint: {
+    /** The index of data being hovered or touched */
+    index: number;
 
-  /** The mouse hovered or touched position */
-  hoveredPos: {
-    x: number;
-    y: number;
+    /** The mouse hovered or touched position */
+    position: {
+      x: number;
+      y: number;
+    };
   };
 
   /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
@@ -69,21 +72,25 @@ export class DataLayer extends React.PureComponent<
 > {
   public state: DataLayerState = {
     hovering: false,
-    hoveredIndex: 0,
-    hoveredPos: {
-      x: 0,
-      y: 0,
+    hoveredPoint: {
+      index: 0,
+      position: {
+        x: 0,
+        y: 0,
+      },
     },
     clearHovering: () => {
       this.setState({ hovering: false });
     },
     setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => {
       this.setState({
-        hoveredIndex,
         hovering: true,
-        hoveredPos: {
-          x: xPos,
-          y: yPos,
+        hoveredPoint: {
+          index: hoveredIndex,
+          position: {
+            x: xPos,
+            y: yPos,
+          },
         },
       });
     },

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -3,6 +3,7 @@ import memoizeOne from 'memoize-one';
 
 import { Scale, DataField, AxisConfig } from '../common/types';
 import { getAxisConfig } from '../utils/getAxisConfig';
+import dataLayerContext, { DataLayerContextInferface } from '../context/dataLayerContext';
 
 export interface DataLayerAxes {
   xAxis: AxisConfig;
@@ -40,20 +41,18 @@ export interface DataLayerProps {
   children: (axes: DataLayerAxes) => React.ReactNode;
 }
 
-export interface DataLayerState {
-  /** TODO: records the indices of data selected by users from the interaction layer */
-  activeDataIndices: number[];
-}
-
 /**
  * The layer is responsible for computing axis data in order to draw a graph
  */
 export class DataLayer extends React.PureComponent<
   DataLayerProps,
-  DataLayerState
+  DataLayerContextInferface
 > {
-  public state: DataLayerState = {
-    activeDataIndices: [],
+  public state: DataLayerContextInferface = {
+    activeDataIndex: null,
+    setActiveDataIndex: (activeDataIndex: number) => {
+      this.setState({ activeDataIndex });
+    },
   };
 
   private getXYAxes = memoizeOne(
@@ -66,6 +65,8 @@ export class DataLayer extends React.PureComponent<
   );
 
   public render() {
+    const { Provider } = dataLayerContext;
+
     const {
       width,
       height,
@@ -85,6 +86,10 @@ export class DataLayer extends React.PureComponent<
       fieldsX,
       fieldsY,
     );
-    return children({ xAxis, yAxis });
+    return (
+      <Provider value={this.state}>
+        {children({ xAxis, yAxis })}
+      </Provider>
+    );
   }
 }

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -4,7 +4,21 @@ import memoizeOne from 'memoize-one';
 import { Scale, DataField, AxisConfig } from '../common/types';
 import { getAxisConfig } from '../utils/getAxisConfig';
 
-export interface DataLayerAxes {
+export interface DataLayerState {
+  /** The index of data being hovered or touched */
+  hoveredIndex: number | null;
+
+  /** The mouse hovered or touched position */
+  hoveredPos: {
+    x: number;
+    y: number;
+  } | null;
+
+  /** Function to record hover or touch interactions, which is used by `<TouchLayer>` */
+  setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
+}
+
+export interface DataLayerRenderParams extends DataLayerState {
   xAxis: AxisConfig;
   yAxis: AxisConfig;
 }
@@ -37,12 +51,7 @@ export interface DataLayerProps {
   fieldsY: DataField[];
 
   /** Render props with the computed configurations for the axes */
-  children: (axes: DataLayerAxes) => React.ReactNode;
-}
-
-export interface DataLayerState {
-  activeDataIndex: number | null;
-  setActiveDataIndex: (activeDataIndex: number) => void;
+  children: (axes: DataLayerRenderParams) => React.ReactNode;
 }
 
 /**
@@ -53,9 +62,16 @@ export class DataLayer extends React.PureComponent<
   DataLayerState
 > {
   public state: DataLayerState = {
-    activeDataIndex: null,
-    setActiveDataIndex: (activeDataIndex: number) => {
-      this.setState({ activeDataIndex });
+    hoveredIndex: null,
+    hoveredPos: null,
+    setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => {
+      this.setState({
+        hoveredIndex,
+        hoveredPos: {
+          x: xPos,
+          y: yPos,
+        },
+      });
     },
   };
 
@@ -90,6 +106,6 @@ export class DataLayer extends React.PureComponent<
       fieldsY,
     );
 
-    return children({ xAxis, yAxis });
+    return children({ xAxis, yAxis, ...this.state });
   }
 }

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -5,8 +5,11 @@ import { Scale, DataField, AxisConfig } from '../common/types';
 import { getAxisConfig } from '../utils/getAxisConfig';
 
 export interface DataLayerState {
+  /** Records whether there is mouse or touch event generating from the inner layer */
+  hovering: boolean;
+
   /** The index of data being hovered or touched */
-  hoveredIndex: number | null;
+  hoveredIndex: number;
 
   /** The mouse hovered or touched position */
   hoveredPos: {
@@ -18,7 +21,7 @@ export interface DataLayerState {
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
 
   /** Function let `<TouchLayer>` hide the tooltip */
-  clearHoveredIndex: () => void;
+  clearHovering: () => void;
 }
 
 export interface DataLayerRenderParams extends DataLayerState {
@@ -65,14 +68,16 @@ export class DataLayer extends React.PureComponent<
   DataLayerState
 > {
   public state: DataLayerState = {
-    hoveredIndex: null,
+    hovering: false,
+    hoveredIndex: 0,
     hoveredPos: null,
-    clearHoveredIndex: () => {
-      this.setState({ hoveredIndex: null });
+    clearHovering: () => {
+      this.setState({ hovering: false });
     },
     setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => {
       this.setState({
         hoveredIndex,
+        hovering: true,
         hoveredPos: {
           x: xPos,
           y: yPos,

--- a/packages/graph/src/layers/DataLayer.tsx
+++ b/packages/graph/src/layers/DataLayer.tsx
@@ -54,6 +54,7 @@ export interface DataLayerProps {
   /** Scale config of the y-axis */
   scaleY: Scale;
 
+  // #TODO: defien the keys for the fields, and the default keys are the index of the record
   /** DataFields of the x-axis */
   fieldsX: DataField[];
 

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -2,14 +2,9 @@ import * as React from 'react';
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
-import { Margin } from '../common/types';
-
 export interface HoverLayerProps {
   /** Set the information related to hover or touch interactions  */
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
-
-  /** Margin between the inner graph area and the outer svg */
-  margin: Margin;
 
   /** Hidden components to detect the mouse or touch interactions */
   collisionComponents: JSX.Element[];
@@ -20,12 +15,6 @@ export interface HoverLayerProps {
 
 export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
-    margin: {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-    },
     debounceTime: 30,
   };
 
@@ -33,16 +22,14 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
 
   /** Updates the position of the tooltip and sets the currently active data index */
   private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
-    const { margin, setHoveredPosAndIndex } = this.props;
-    const { left, top } = margin;
+    const { setHoveredPosAndIndex } = this.props;
     // TODO: integrate `localPoint` of vx
     const { x, y } = localPoint(event);
-    console.log(x - left, y - top);
     this.animaFrameID = window.requestAnimationFrame(() => {
       setHoveredPosAndIndex(
         dataIndex,
-        x - left,
-        y - top,
+        x,
+        y,
       );
     });
   };

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -7,7 +7,7 @@ export interface HoverLayerProps {
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
 
   /** Function to hide the tooltip */
-  clearHoveredIndex: () => void;
+  clearHovering: () => void;
 
   /** Hidden components to detect the mouse or touch interactions */
   collisionComponents: JSX.Element[];
@@ -18,7 +18,7 @@ export interface HoverLayerProps {
 
 export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
-    throttleTime: 100,
+    throttleTime: 180,
   };
 
   public animaFrameID: number;
@@ -48,7 +48,7 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   private hideTooltip = () => {
     // cancel the previously thorttled event to prevent the tooltip from reappearing
     this.throttledUpdatePosition.cancel();
-    this.props.clearHoveredIndex();
+    this.props.clearHovering();
   };
 
   public componentWillUnmount() {

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -4,22 +4,9 @@ import { localPoint } from '@vx/event';
 
 import { Margin } from '../common/types';
 
-export interface HoverLayerState {
-  /** X position of the tooltip relative to the position of the inner graph */
-  xPos: number;
-
-  /** Y position of the tooltip relative to the position of the inner graph */
-  yPos: number;
-
-  /** Currently hovered or touched index of data */
-  activeDataIndex: number | null;
-}
 export interface HoverLayerProps {
-  /** Width of the inner graph */
-  width: number;
-
-  /** height of the inner graph */
-  height: number;
+  /** Set the information related to hover or touch interactions  */
+  setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
 
   /** Margin between the inner graph area and the outer svg */
   margin: Margin;
@@ -29,15 +16,9 @@ export interface HoverLayerProps {
 
   /** The debounce time for the mouse and touch events */
   debounceTime: number;
-
-  /** Render props to render the tooltip box */
-  children: (state: HoverLayerState) => React.ReactNode;
 }
 
-export class HoverLayer extends React.PureComponent<
-  HoverLayerProps,
-  HoverLayerState
-> {
+export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
     margin: {
       top: 0,
@@ -50,25 +31,19 @@ export class HoverLayer extends React.PureComponent<
 
   public animaFrameID: number;
 
-  public state: HoverLayerState = {
-    xPos: 0,
-    yPos: 0,
-    activeDataIndex: null,
-  };
-
   /** Updates the position of the tooltip and sets the currently active data index */
   private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
-    const { margin } = this.props;
+    const { margin, setHoveredPosAndIndex } = this.props;
     const { left, top } = margin;
     // TODO: integrate `localPoint` of vx
     const { x, y } = localPoint(event);
     console.log(x - left, y - top);
     this.animaFrameID = window.requestAnimationFrame(() => {
-      this.setState({
-        xPos: x - left,
-        yPos: y - top,
-        activeDataIndex: dataIndex,
-      });
+      setHoveredPosAndIndex(
+        dataIndex,
+        x - left,
+        y - top,
+      );
     });
   };
 
@@ -85,8 +60,7 @@ export class HoverLayer extends React.PureComponent<
   }
 
   public render() {
-    const { activeDataIndex, xPos, yPos } = this.state;
-    const { collisionComponents, children } = this.props;
+    const { collisionComponents } = this.props;
     const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
       const handleCurrentTooltip = this.handleTooltip(dataIndex);
       return React.cloneElement(area, {

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -10,12 +10,12 @@ export interface HoverLayerProps {
   collisionComponents: JSX.Element[];
 
   /** The debounce time for the mouse and touch events */
-  debounceTime: number;
+  throttleTime: number;
 }
 
 export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
-    debounceTime: 30,
+    throttleTime: 30,
   };
 
   public animaFrameID: number;
@@ -34,7 +34,7 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
     });
   };
 
-  private throttledUpdatePosition = throttle(this.updatePosition, this.props.debounceTime);
+  private throttledUpdatePosition = throttle(this.updatePosition, this.props.throttleTime);
 
   private handleTooltip = (dataIndex: number) => (event: React.SyntheticEvent) => {
     // removes it from the event pool and allows references to the event

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -15,7 +15,7 @@ export interface HoverLayerProps {
 
 export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
-    throttleTime: 30,
+    throttleTime: 100,
   };
 
   public animaFrameID: number;

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -6,6 +6,9 @@ export interface HoverLayerProps {
   /** Set the information related to hover or touch interactions  */
   setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
 
+  /** Function to hide the tooltip */
+  clearHoveredIndex: () => void;
+
   /** Hidden components to detect the mouse or touch interactions */
   collisionComponents: JSX.Element[];
 
@@ -42,6 +45,12 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
     this.throttledUpdatePosition(dataIndex, event);
   };
 
+  private hideTooltip = () => {
+    // cancel the previously thorttled event to prevent the tooltip from reappearing
+    this.throttledUpdatePosition.cancel();
+    this.props.clearHoveredIndex();
+  };
+
   public componentWillUnmount() {
     window.cancelAnimationFrame(this.animaFrameID);
   }
@@ -54,6 +63,7 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
         onTouchStart: handleCurrentTooltip,
         onTouchMove: handleCurrentTooltip,
         onMouseMove: handleCurrentTooltip,
+        onMouseLeave: this.hideTooltip,
       });
     });
 

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -28,7 +28,7 @@ export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   /** Updates the position of the tooltip and sets the currently active data index */
   private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
     const { setHoveredPosAndIndex } = this.props;
-    // TODO: integrate `localPoint` of vx
+    // convert the position of the event to the coordinate system of the SVG
     const { x, y } = localPoint(event);
     this.animaFrameID = window.requestAnimationFrame(() => {
       setHoveredPosAndIndex(

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
-import { DataLayerState } from './DataLayer';
+import { DataLayerRenderParams } from './DataLayer';
 
 export interface HoverLayerProps {
   /** Set the information related to hover or touch interactions  */
-  setHoveredPosAndIndex: DataLayerState['setHoveredPosAndIndex'];
+  setHoveredPosAndIndex: DataLayerRenderParams['setHoveredPosAndIndex'];
 
   /** Function to hide the tooltip */
   clearHovering: () => void;

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
+import { DataLayerState } from './DataLayer';
+
 export interface HoverLayerProps {
   /** Set the information related to hover or touch interactions  */
-  setHoveredPosAndIndex: (hoveredIndex: number, xPos: number, yPos: number) => void;
+  setHoveredPosAndIndex: DataLayerState['setHoveredPosAndIndex'];
 
   /** Function to hide the tooltip */
   clearHovering: () => void;

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -8,6 +8,9 @@ export interface HoverLayerProps {
   /** Set the information related to hover or touch interactions  */
   setHoveredPosAndIndex: DataLayerRenderParams['setHoveredPosAndIndex'];
 
+  /** Function to be called before the latest tooltip position is set */
+  handleHover: () => void;
+
   /** Function to hide the tooltip */
   clearHovering: () => void;
 
@@ -21,13 +24,18 @@ export interface HoverLayerProps {
 export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
   public static defaultProps = {
     throttleTime: 180,
+    handleHover: () => null,
   };
 
   public animaFrameID: number;
 
   /** Updates the position of the tooltip and sets the currently active data index */
   private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
-    const { setHoveredPosAndIndex } = this.props;
+    const { setHoveredPosAndIndex, handleHover } = this.props;
+
+    // custom action which executes before the position is updated
+    handleHover();
+
     // convert the position of the event to the coordinate system of the SVG
     const { x, y } = localPoint(event);
     this.animaFrameID = window.requestAnimationFrame(() => {

--- a/packages/graph/src/layers/ResponsiveLayer.tsx
+++ b/packages/graph/src/layers/ResponsiveLayer.tsx
@@ -82,7 +82,7 @@ export class ResponsiveLayer extends React.Component<
     return (
       <div
         ref={this.layerRef}
-        style={{ ...style, width: '100%', height: '100%' }}
+        style={{ ...style, width: '100%', height: '100%', position: 'relative' }}
         className={className}
         {...restProps}
       >

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import { Margin, FieldSelector } from '../common/types';
+import { Tooltip } from '../tooltip/Tooltip';
+import { TooltipItem } from '../tooltip/TooltipItem';
+
+import { DataLayerRenderParams } from './DataLayer';
+
+export interface TooltipLayerProps {
+  hovering: DataLayerRenderParams['hovering'];
+  hoveredPoint: DataLayerRenderParams['hoveredPoint'];
+  data: object[];
+  graphWidth: number;
+  graphHeight: number;
+  margin: Margin;
+  xSelector: FieldSelector;
+  ySelector: FieldSelector;
+}
+
+/** Generates the tooltip box */
+export const TooltipLayer: React.FC<TooltipLayerProps> = ({
+  hovering,
+  hoveredPoint,
+  data,
+  graphWidth,
+  graphHeight,
+  margin,
+  xSelector,
+  ySelector,
+}) => {
+  const { index, position } = hoveredPoint;
+
+  return (
+    <Tooltip
+      graphWidth={graphWidth}
+      graphHeight={graphHeight}
+      graphMargin={margin}
+      position={{
+        x: xSelector.getScaledVal(data[index]),
+        y: position.y,
+      }}
+      show={hovering}
+    >
+      <h3>{xSelector.getFormattedStringVal(data[index])}</h3>
+      {/* TODO: unify the way of dealing colors of the fields */}
+      <TooltipItem color="#ff7049" text={ySelector.getFormattedStringVal(data[index])} />
+    </Tooltip>
+  );
+};

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+export interface TooltipLayerProps {
+
+}
+
+export interface TooltipLayerState {
+  /** X position of the tooltip */
+  xPos: number;
+
+  /** Y position of the tooltip */
+  yPos: number;
+}
+
+export class TooltipLayer extends React.Component<
+  TooltipLayerProps,
+  TooltipLayerState
+> {
+
+  public state: TooltipLayerState = {
+    xPos: 0,
+    yPos: 0,
+  };
+
+  private handleTooltip = (dataIndex) => (event) => {
+    // TODO: integrate `localPoint` of vx
+    this.setState();
+  };
+
+  public render() {
+    const { activeDataIndex } = this.context;
+    const { renderCollisionAreas } = this.props;
+    const collideAreas = renderCollisionAreas.map((area: JSX.Element, dataIndex: number) => {
+      const handleCurrentTooltip = this.handleTooltip(dataIndex);
+      return React.cloneElement(area, { onTouchStart: handleCurrentTooltip });
+    });
+
+    return (
+      <>
+        {/* Render areas to detect collisions of mouse pointers or touches with data points */}
+        {collideAreas}
+      </>
+    );
+  }
+}

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -1,14 +1,21 @@
 import * as React from 'react';
+import { localPoint } from '@vx/event';
+
+import { Margin } from '../common/types';
 
 export interface TooltipLayerProps {
+  /** Margin between the inner graph area and the outer svg */
+  margin: Margin;
 
+  /** Hidden components to detect the mouse or touch interactions */
+  collisionComponents: JSX.Element[];
 }
 
 export interface TooltipLayerState {
-  /** X position of the tooltip */
+  /** X position of the tooltip relative to the position of the inner graph */
   xPos: number;
 
-  /** Y position of the tooltip */
+  /** Y position of the tooltip relative to the position of the inner graph */
   yPos: number;
 }
 
@@ -16,29 +23,49 @@ export class TooltipLayer extends React.Component<
   TooltipLayerProps,
   TooltipLayerState
 > {
+  public static defaultProps = {
+    margin: {
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+    },
+  };
 
   public state: TooltipLayerState = {
     xPos: 0,
     yPos: 0,
   };
 
-  private handleTooltip = (dataIndex) => (event) => {
+  private handleTooltip = (dataIndex: number) => (event: MouseEvent | TouchEvent) => {
+    const { margin } = this.props;
+    const { left, top } = margin;
     // TODO: integrate `localPoint` of vx
-    this.setState();
+    const { x, y } = localPoint(event);
+    console.log('node.createSVGPoint', localPoint(event), x - left, y - top)
+    this.setState({
+      xPos: x - left,
+      yPos: y - top,
+    });
+    // this.context.setActiveDataIndex(dataIndex);
   };
 
   public render() {
     const { activeDataIndex } = this.context;
-    const { renderCollisionAreas } = this.props;
-    const collideAreas = renderCollisionAreas.map((area: JSX.Element, dataIndex: number) => {
+    const { collisionComponents } = this.props;
+    const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
       const handleCurrentTooltip = this.handleTooltip(dataIndex);
-      return React.cloneElement(area, { onTouchStart: handleCurrentTooltip });
+      return React.cloneElement(area, {
+        onTouchStart: handleCurrentTooltip,
+        onTouchMove: handleCurrentTooltip,
+        onMouseMove: handleCurrentTooltip,
+      });
     });
 
     return (
       <>
         {/* Render areas to detect collisions of mouse pointers or touches with data points */}
-        {collideAreas}
+        {detectionAreas}
       </>
     );
   }

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -57,7 +57,6 @@ export class TooltipLayer extends React.PureComponent<
         yPos: y - top,
       });
     });
-    // this.context.setActiveDataIndex(dataIndex);
   };
 
   private throttledUpdatePosition = throttle(this.updatePosition, this.props.debounceTime);

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
 import { Margin } from '../common/types';
@@ -9,6 +10,9 @@ export interface TooltipLayerProps {
 
   /** Hidden components to detect the mouse or touch interactions */
   collisionComponents: JSX.Element[];
+
+  /** The debounce time for the mouse and touch events */
+  debounceTime: number;
 }
 
 export interface TooltipLayerState {
@@ -19,7 +23,7 @@ export interface TooltipLayerState {
   yPos: number;
 }
 
-export class TooltipLayer extends React.Component<
+export class TooltipLayer extends React.PureComponent<
   TooltipLayerProps,
   TooltipLayerState
 > {
@@ -30,29 +34,47 @@ export class TooltipLayer extends React.Component<
       bottom: 0,
       left: 0,
     },
+    debounceTime: 30,
   };
+
+  public animaFrameID: number;
 
   public state: TooltipLayerState = {
     xPos: 0,
     yPos: 0,
   };
 
-  private handleTooltip = (dataIndex: number) => (event: MouseEvent | TouchEvent) => {
+  /** Updates the position of the tooltip and sets the currently active data index */
+  private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
     const { margin } = this.props;
     const { left, top } = margin;
     // TODO: integrate `localPoint` of vx
     const { x, y } = localPoint(event);
-    console.log('node.createSVGPoint', localPoint(event), x - left, y - top)
-    this.setState({
-      xPos: x - left,
-      yPos: y - top,
+    console.log(x - left, y - top)
+    this.animaFrameID = window.requestAnimationFrame(() => {
+      this.setState({
+        xPos: x - left,
+        yPos: y - top,
+      });
     });
     // this.context.setActiveDataIndex(dataIndex);
   };
 
+  private throttledUpdatePosition = throttle(this.updatePosition, this.props.debounceTime);
+
+  private handleTooltip = (dataIndex: number) => (event: React.SyntheticEvent) => {
+    // removes it from the event pool and allows references to the event
+    event.persist();
+    this.throttledUpdatePosition(dataIndex, event);
+  };
+
+  public componentWillUnmount() {
+    window.cancelAnimationFrame(this.animaFrameID);
+  }
+
   public render() {
     const { activeDataIndex } = this.context;
-    const { collisionComponents } = this.props;
+    const { collisionComponents, debounceTime } = this.props;
     const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
       const handleCurrentTooltip = this.handleTooltip(dataIndex);
       return React.cloneElement(area, {

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -17,6 +17,10 @@ const TooltipWrapper = styled.div`
   border-radius: 1.2rem;
   font-size: 1rem;
   white-space: nowrap;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  transition: all 150ms ease-in;
 `;
 
 export const Tooltip: React.SFC<TooltipProps> = ({
@@ -28,7 +32,7 @@ export const Tooltip: React.SFC<TooltipProps> = ({
   }
 
   return (
-    <TooltipWrapper style={{ top: position.y, left: position.x }}>
+    <TooltipWrapper style={{ transform: `translate(${position.x}px, ${position.y}px)`  }}>
       {children}
     </TooltipWrapper>
   );

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -3,27 +3,32 @@ import * as React from 'react';
 import { styled } from '../utils/styled-components';
 
 export interface TooltipProps {
-  top: number;
-  left: number;
+  position: {
+    x: number;
+    y: number;
+  } | null;
   children: React.ReactNode;
 }
 
 const TooltipWrapper = styled.div`
   position: absolute;
   background-color: rgba(239, 235, 235, 0.8);
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 1.2rem;
   border-radius: 1.2rem;
   font-size: 1rem;
   white-space: nowrap;
 `;
 
 export const Tooltip: React.SFC<TooltipProps> = ({
-  top = 0,
-  left = 0,
+  position,
   children,
 }) => {
+  if (!position) {
+    return null;
+  }
+
   return (
-    <TooltipWrapper style={{ top, left }}>
+    <TooltipWrapper style={{ top: position.y, left: position.x }}>
       {children}
     </TooltipWrapper>
   );

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Transition, animated } from 'react-spring';
 
 import { styled } from '../utils/styled-components';
 
@@ -7,6 +8,7 @@ export interface TooltipProps {
     x: number;
     y: number;
   } | null;
+  show: boolean;
   children: React.ReactNode;
 }
 
@@ -20,20 +22,37 @@ const TooltipWrapper = styled.div`
   top: 0;
   left: 0;
   pointer-events: none;
-  transition: all 150ms ease-in;
+  transition: all 200ms ease-in;
 `;
 
 export const Tooltip: React.SFC<TooltipProps> = ({
   position,
   children,
+  show = false,
 }) => {
   if (!position) {
     return null;
   }
 
   return (
-    <TooltipWrapper style={{ transform: `translate(${position.x}px, ${position.y}px)`  }}>
-      {children}
-    </TooltipWrapper>
+    // use Transition to control the mounting/unmounting of Tooltip
+    <Transition
+      items={show}
+      unique
+      native
+      from={{ opacity: 0 }}
+      enter={{ opacity: 1 }}
+      leave={{ opacity: 0 }}
+    >
+      {showing =>
+        showing && (props =>
+          <animated.div style={{ ...props, transition: 'opacity 0.1s ease-out' }}>
+            <TooltipWrapper style={{ transform: `translate(${position.x}px, ${position.y}px)` }}>
+              {children}
+            </TooltipWrapper>
+          </animated.div>
+        )
+      }
+    </Transition>
   );
 };

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Transition, animated } from 'react-spring';
 
 import { styled } from '../utils/styled-components';
+import { Margin } from '../common/types';
 
 export interface TooltipProps {
   position: {
@@ -12,6 +13,7 @@ export interface TooltipProps {
   children: React.ReactNode;
   graphWidth: number;
   graphHeight: number;
+  graphMargin: Margin;
 }
 
 const TooltipWrapper = styled.div`
@@ -34,13 +36,16 @@ const TooltipWrapper = styled.div`
 function getTooltipPosition(
   graphWidth: TooltipProps['graphWidth'],
   graphHeight: TooltipProps['graphHeight'],
+  graphMargin: Margin,
   position: TooltipProps['position'],
 ) {
-  const percentX = Math.round(-100 * (position.x / graphWidth));
+  const onRightHalf = (position.x / graphWidth) > 0.5;
+  const percentX = onRightHalf ? -100 : 0;
   const percentY = Math.round(-100 * (position.y / graphHeight));
+  const leftOffset = onRightHalf ? -20 : 20;
   return {
-    top: `${position.y}px`,
-    left: `${position.x}px`,
+    top: `${graphMargin.top + position.y}px`,
+    left: `${graphMargin.left + position.x + leftOffset}px`,
     transform: `translate(${percentX}%, ${percentY}%)`,
   };
 }
@@ -51,12 +56,18 @@ export const Tooltip: React.SFC<TooltipProps> = ({
   show = false,
   graphWidth,
   graphHeight,
+  graphMargin = {
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  },
 }) => {
   if (!position) {
     return null;
   }
 
-  const tooltipStyle = getTooltipPosition(graphWidth, graphHeight, position);
+  const tooltipStyle = getTooltipPosition(graphWidth, graphHeight, graphMargin, position);
 
   return (
     // use Transition to control the mounting/unmounting of Tooltip

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -18,15 +18,23 @@ export interface TooltipProps {
 
 const TooltipWrapper = styled.div`
   position: absolute;
-  background-color: rgba(239, 235, 235, 0.8);
+  min-width: 3rem;
+  background-color: rgba(255, 255, 255, 0.8);
   padding: 0.5rem 1.2rem;
-  border-radius: 1.2rem;
+  border-radius: 5px;
   font-size: 1rem;
   white-space: nowrap;
   top: 0;
   left: 0;
   pointer-events: none;
   transition: all 500ms linear;
+  box-shadow: 0px 2px 8px 3px rgba(120,120,120,0.3);
+
+  h3 {
+    color: #7c8a94;
+    margin: 0.25rem 0;
+    font-size: 1.1rem;
+  }
 `;
 
 /**
@@ -42,7 +50,7 @@ function getTooltipPosition(
   const onRightHalf = (position.x / graphWidth) > 0.5;
   const percentX = onRightHalf ? -100 : 0;
   const percentY = Math.round(-100 * (position.y / graphHeight));
-  const leftOffset = onRightHalf ? -20 : 20;
+  const leftOffset = onRightHalf ? -10 : 10;
   return {
     top: `${graphMargin.top + position.y}px`,
     left: `${graphMargin.left + position.x + leftOffset}px`,

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -50,7 +50,7 @@ function getTooltipPosition(
   const onRightHalf = (position.x / graphWidth) > 0.5;
   const percentX = onRightHalf ? -100 : 0;
   const percentY = Math.round(-100 * (position.y / graphHeight));
-  const leftOffset = onRightHalf ? -10 : 10;
+  const leftOffset = onRightHalf ? -20 : 20;
   return {
     top: `${graphMargin.top + position.y}px`,
     left: `${graphMargin.left + position.x + leftOffset}px`,

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -24,7 +24,7 @@ const TooltipWrapper = styled.div`
   top: 0;
   left: 0;
   pointer-events: none;
-  transition: all 200ms ease-in;
+  transition: all 500ms linear;
 `;
 
 /**

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import { styled } from '../utils/styled-components';
+
+export interface TooltipProps {
+  top: number;
+  left: number;
+  children: React.ReactNode;
+}
+
+const TooltipWrapper = styled.div`
+  position: absolute;
+  background-color: rgba(239, 235, 235, 0.8);
+  padding: 0.5rem 1rem;
+  border-radius: 1.2rem;
+  font-size: 1rem;
+  white-space: nowrap;
+`;
+
+export const Tooltip: React.SFC<TooltipProps> = ({
+  top = 0,
+  left = 0,
+  children,
+}) => {
+  return (
+    <TooltipWrapper style={{ top, left }}>
+      {children}
+    </TooltipWrapper>
+  );
+};

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -7,9 +7,11 @@ export interface TooltipProps {
   position: {
     x: number;
     y: number;
-  } | null;
+  };
   show: boolean;
   children: React.ReactNode;
+  graphWidth: number;
+  graphHeight: number;
 }
 
 const TooltipWrapper = styled.div`
@@ -25,14 +27,36 @@ const TooltipWrapper = styled.div`
   transition: all 200ms ease-in;
 `;
 
+/**
+ * Returns the position and transform
+ * which limit the tooltip within the bound of the graph
+ */
+function getTooltipPosition(
+  graphWidth: TooltipProps['graphWidth'],
+  graphHeight: TooltipProps['graphHeight'],
+  position: TooltipProps['position'],
+) {
+  const percentX = Math.round(-100 * (position.x / graphWidth));
+  const percentY = Math.round(-100 * (position.y / graphHeight));
+  return {
+    top: `${position.y}px`,
+    left: `${position.x}px`,
+    transform: `translate(${percentX}%, ${percentY}%)`,
+  };
+}
+
 export const Tooltip: React.SFC<TooltipProps> = ({
   position,
   children,
   show = false,
+  graphWidth,
+  graphHeight,
 }) => {
   if (!position) {
     return null;
   }
+
+  const tooltipStyle = getTooltipPosition(graphWidth, graphHeight, position);
 
   return (
     // use Transition to control the mounting/unmounting of Tooltip
@@ -47,7 +71,7 @@ export const Tooltip: React.SFC<TooltipProps> = ({
       {showing =>
         showing && (props =>
           <animated.div style={{ ...props, transition: 'opacity 0.1s ease-out' }}>
-            <TooltipWrapper style={{ transform: `translate(${position.x}px, ${position.y}px)` }}>
+            <TooltipWrapper style={tooltipStyle}>
               {children}
             </TooltipWrapper>
           </animated.div>

--- a/packages/graph/src/tooltip/TooltipItem.tsx
+++ b/packages/graph/src/tooltip/TooltipItem.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+
+import { styled } from '../utils/styled-components';
+
+export interface TooltipItemProps {
+  color: string;
+  text: string;
+}
+
+const ItemWrapper = styled.div`
+  margin: 0.25rem 0;
+
+  &:before {
+    content: '';
+    width: 0.35rem;
+    height: 0.35rem;
+    background-color: ${({ color }) => color};
+    float: left;
+    margin: 0.5rem 0.8rem 0 0.2rem;
+    border-radius: 50%;
+  }
+`;
+
+export const TooltipItem: React.SFC<TooltipItemProps> = ({
+  color = 'gray',
+  text,
+}) => {
+  return (
+    <ItemWrapper color={color}>
+      {text}
+    </ItemWrapper>
+  );
+};

--- a/packages/graph/src/utils/getAxisConfig.ts
+++ b/packages/graph/src/utils/getAxisConfig.ts
@@ -61,7 +61,8 @@ export function getAxisConfig(
     fields,
     range,
     domain,
-    d3Scale,
     getValue,
+    d3Scale,
+    scaleConfig: scale,
   };
 }

--- a/packages/graph/src/utils/getAxisConfig.ts
+++ b/packages/graph/src/utils/getAxisConfig.ts
@@ -7,6 +7,8 @@ import {
 
 import { Scale, DataField, AxisConfig } from '../common/types';
 
+import { getRecordFieldSelectors } from './getRecordFieldSelectors';
+
 /**
  * Computes and returns the configurations for the axis,
  * such as its domain, range and d3 scale functions
@@ -57,12 +59,17 @@ export function getAxisConfig(
       throw new Error('Unsupported scale type');
   }
 
-  return {
+  const axisConfig = {
     fields,
     range,
     domain,
     getValue,
     d3Scale,
     scaleConfig: scale,
+  };
+
+  return {
+    ...axisConfig,
+    getSelectorsByField: (fieldIndex: number) => getRecordFieldSelectors(axisConfig, fieldIndex),
   };
 }

--- a/packages/graph/src/utils/getRecordFieldSelectors.ts
+++ b/packages/graph/src/utils/getRecordFieldSelectors.ts
@@ -1,0 +1,42 @@
+import { AxisConfig } from '../common/types';
+
+export interface FieldSelector {
+  getOriginalVal: (record: object) => any;
+  getScaledVal: (record: object) => any;
+  getFormattedStringVal: (record: object) => string;
+}
+
+/**
+ * Returns the data value selectors for a data record
+ * using the computed axis configurations including the d3Scale function of the axis
+ * @param axis - the axis computed from DataLayer
+ * @param fieldIndex - the current index of the field
+ */
+export function getRecordFieldSelectors(axis: AxisConfig, fieldIndex: number) {
+  const { fields, d3Scale, getValue, scaleConfig } = axis;
+  const fieldName = fields[fieldIndex].name;
+
+  /** Given a record of data, it returns the orginal value of the specified field */
+  const getOriginalVal = (record: object) => getValue(record[fieldName]);
+
+  return {
+    getOriginalVal,
+
+    /**
+     * Given a record of data,
+     * it returns the mapped value (computed by d3 scale function) of the specified field
+     */
+    getScaledVal: (record: object) => d3Scale(getOriginalVal(record)),
+
+    getFormattedStringVal: (record: object) => {
+      const recordValue = getOriginalVal(record);
+
+      if (scaleConfig.type === 'time') {
+        // FIXME: unify the way of formatting datetime
+        return recordValue.toLocaleString();
+      }
+
+      return recordValue;
+    },
+  };
+}

--- a/packages/graph/src/utils/getRecordFieldSelectors.ts
+++ b/packages/graph/src/utils/getRecordFieldSelectors.ts
@@ -1,18 +1,15 @@
 import { AxisConfig } from '../common/types';
 
-export interface FieldSelector {
-  getOriginalVal: (record: object) => any;
-  getScaledVal: (record: object) => any;
-  getFormattedStringVal: (record: object) => string;
-}
-
 /**
  * Returns the data value selectors for a data record
  * using the computed axis configurations including the d3Scale function of the axis
  * @param axis - the axis computed from DataLayer
  * @param fieldIndex - the current index of the field
  */
-export function getRecordFieldSelectors(axis: AxisConfig, fieldIndex: number) {
+export function getRecordFieldSelectors(
+  axis: Pick<AxisConfig, Exclude<keyof AxisConfig, 'getSelectorsByField'>>,
+  fieldIndex: number,
+) {
   const { fields, d3Scale, getValue, scaleConfig } = axis;
   const fieldName = fields[fieldIndex].name;
 

--- a/packages/graph/src/utils/styled-components/index.ts
+++ b/packages/graph/src/utils/styled-components/index.ts
@@ -1,0 +1,16 @@
+import * as styledComponents from 'styled-components';
+
+export interface ThemeInterface {
+  primaryColor: string;
+  primaryColorInverted: string;
+}
+
+const {
+  default: styled,
+  css,
+  createGlobalStyle,
+  keyframes,
+  ThemeProvider,
+} = styledComponents as styledComponents.ThemedStyledComponentsModule<ThemeInterface>;
+
+export { styled, css, createGlobalStyle, keyframes, ThemeProvider };

--- a/types/vx-event/index.d.ts
+++ b/types/vx-event/index.d.ts
@@ -4,6 +4,6 @@ declare module '@vx/event' {
     y: number;
   }
 
-  function localPoint(event: UIEvent): Point;
-  function localPoint(node: React.ReactNode, event: UIEvent): Point;
+  function localPoint(event: React.SyntheticEvent): Point;
+  function localPoint(node: React.ReactNode, event: React.SyntheticEvent): Point;
 }

--- a/types/vx-event/index.d.ts
+++ b/types/vx-event/index.d.ts
@@ -1,0 +1,9 @@
+declare module '@vx/event' {
+  interface Point {
+    x: number;
+    y: number;
+  }
+
+  function localPoint(event: UIEvent): Point;
+  function localPoint(node: React.ReactNode, event: UIEvent): Point;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8843,6 +8843,13 @@ react-sizes@^1.0.4:
     lodash.throttle "^4.1.1"
     prop-types "^15.6.0"
 
+react-spring@^7.2.10:
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-7.2.10.tgz#eacbf429327bea058677c3a01af87b9c387f4aa6"
+  integrity sha512-bsbgQh1DzTqjwuD1tDZ7Nu04G5JhNNXdezkcJ5xXNboedN/MPe0K+X/MtypUxXBUCLYT0r5oKT3zj4STqVpnPA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 react@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.7.0.tgz#b674ec396b0a5715873b350446f7ea0802ab6381"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1944,6 +1944,13 @@
   dependencies:
     d3-shape "^1.0.6"
 
+"@vx/event@^0.0.182":
+  version "0.0.182"
+  resolved "https://registry.yarnpkg.com/@vx/event/-/event-0.0.182.tgz#b5b20a4e14fcd383511ef7a318ca0a10e6da8140"
+  integrity sha512-kEnBfcyuSep3QdlpQjMRE4jSCcEC1xIcnIFkDGuTWLutlUgIP//o5VbeHIW4xLcOhLe4BjuMuPgmUNZB5nL5Cw==
+  dependencies:
+    "@vx/point" "0.0.182"
+
 "@vx/group@0.0.183":
   version "0.0.183"
   resolved "https://registry.yarnpkg.com/@vx/group/-/group-0.0.183.tgz#15c8b14c5cadbe5f76c3ddcab8c5698cae24b443"

--- a/yarn.lock
+++ b/yarn.lock
@@ -790,7 +790,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
   integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
 
-"@emotion/is-prop-valid@0.7.3":
+"@emotion/is-prop-valid@0.7.3", "@emotion/is-prop-valid@^0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
   integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
@@ -841,7 +841,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.3.tgz#3ca7e9bcb31b3cb4afbaeb66156d86ee85e23246"
   integrity sha512-M3nMfJ6ndJMYloSIbYEBq6G3eqoYD41BpDOxreE8j0cb4fzz/5qvmqU9Mb2hzsXcCnIlGlWhS03PCzVGvTAe0Q==
 
-"@emotion/unitless@0.7.3":
+"@emotion/unitless@0.7.3", "@emotion/unitless@^0.7.0":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
   integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
@@ -1903,6 +1903,15 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/styled-components@^4.1.6":
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.6.tgz#9aa1d47dbc6bae540083869bcc6c639c6e9af0fe"
+  integrity sha512-w/ra/Tk9oPMvWpWId7esZNY1MOa6E9BYUPLl4scVJdYnrYuy5ITLbku8dGDCVH/vjjuegrHBCRYvFLQOYJ+uHg==
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+    csstype "^2.2.0"
+
 "@types/unist@*", "@types/unist@^2.0.0":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.2.tgz#5dc0a7f76809b7518c0df58689cd16a19bd751c6"
@@ -2567,6 +2576,16 @@ babel-plugin-react-docgen@^2.0.0:
   dependencies:
     lodash "^4.17.10"
     react-docgen "^3.0.0-rc.1"
+
+"babel-plugin-styled-components@>= 1":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  integrity sha512-sQVKG8irFXx14ZfaK1bBePirfkacl3j8nZwSZK+ZjsbnadRHKQTbhXbe/RB1vT6Vgkz45E+V95LBq4KqdhZUNw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.10"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -3772,6 +3791,11 @@ css-animation@^1.3.2:
     babel-runtime "6.x"
     component-classes "^1.2.5"
 
+css-color-keywords@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
+
 css-select-base-adapter@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz#3b2ff4972cc362ab88561507a95408a1432135d7"
@@ -3786,6 +3810,15 @@ css-select@^2.0.0:
     css-what "^2.1.2"
     domutils "^1.7.0"
     nth-check "^1.0.2"
+
+css-to-react-native@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.2.2.tgz#c077d0f7bf3e6c915a539e7325821c9dd01f9965"
+  integrity sha512-w99Fzop1FO8XKm0VpbQp3y5mnTnaS+rtCvS+ylSEOK76YXO5zoHQx/QMB1N54Cp+Ya9jB9922EHrh14ld4xmmw==
+  dependencies:
+    css-color-keywords "^1.0.0"
+    fbjs "^0.8.5"
+    postcss-value-parser "^3.3.0"
 
 css-tree@1.0.0-alpha.28:
   version "1.0.0-alpha.28"
@@ -4963,7 +4996,7 @@ faye-websocket@~0.11.0, faye-websocket@~0.11.1:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.0:
+fbjs@^0.8.0, fbjs@^0.8.5:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7092,6 +7125,11 @@ mem@^4.0.0:
     mimic-fn "^1.0.0"
     p-is-promise "^1.1.0"
 
+memoize-one@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.1.0.tgz#a2387c58c03fff27ca390c31b764a79addf3f906"
+  integrity sha512-2GApq0yI/b22J2j9rhbrAlsHb0Qcz+7yWxeLG8h+95sl1XPUgeLimQSOdur4Vw7cUhrBHwaUZxWFZueojqNRzA==
+
 memoize-one@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.0.0.tgz#d55007dffefb8de7546659a1722a5d42e128286e"
@@ -8294,6 +8332,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-value-parser@^3.3.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
+  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -8378,7 +8421,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.6.2, prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@15.6.2, prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -8721,6 +8764,11 @@ react-imported-component@^5.2.4:
     detect-node "^2.0.3"
     prop-types "15.6.2"
     scan-directory "^1.0.0"
+
+react-is@^16.6.0:
+  version "16.7.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
+  integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -10063,12 +10111,39 @@ strong-log-transformer@^2.0.0:
     minimist "^1.2.0"
     through "^2.3.4"
 
+styled-components@^4.1.3:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.1.3.tgz#4472447208e618b57e84deaaeb6acd34a5e0fe9b"
+  integrity sha512-0quV4KnSfvq5iMtT0RzpMGl/Dg3XIxIxOl9eJpiqiq4SrAmR1l1DLzNpMzoy3DyzdXVDMJS2HzROnXscWA3SEw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.7.3"
+    "@emotion/unitless" "^0.7.0"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^2.2.2"
+    memoize-one "^4.0.0"
+    prop-types "^15.5.4"
+    react-is "^16.6.0"
+    stylis "^3.5.0"
+    stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+stylis-rule-sheet@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
+  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
+
+stylis@^3.5.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
+  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.1.0, supports-color@^5.3.0:
+supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==


### PR DESCRIPTION
## Purpose

Traditionally, each chart defines its own way of handling hovering interactions to display to tooltips.

However, handling the mouse and touch events for each type of chart might be burdensome. Additionally, it might be hard to maintain since all of the calculations and data mapping such as converting the hovered position to the actual data point are bound in a single component.

Thus, we make changes to the `<DataLayer>` and introduce `<HoverLayer>` in order to  **reuse the hovering interactions logic** across different graphs and integrate it into `<LineChart>` as an example.

![screencast 2019-02-11 17-44-01](https://user-images.githubusercontent.com/1139698/52555825-c416b180-2e25-11e9-8e48-46a5057ef695.gif)

## Approach

The following diagram shows how the tooltip and hovered effects (such as the enlarged point) are generated:

![linechart-pt2](https://user-images.githubusercontent.com/1139698/52609339-e5c07900-2eb7-11e9-8cff-74fc650775fa.jpg)

### Keep all of the hovering information in the `<DataLayer>`: 
- `hovering`: whether the user is hovering or touching the graph
- `hoveredPoint`: the most recent position and the index of data being hovered

In addition, to unify the way of selecting and converting the value in a record of data, e.g., selecting the `date` field from the record `{ x: 0, y: 9, date: '2019/01/21 00:00:00', weekday: 'Mon' }` and converting it to the `Date` object, `getSelectorsByField` is added to the axis in `<DataLayer>` to return the following data selectors:

- `getOriginalVal`: given a record of data, it returns the original value of the specified field
- `getScaledVal`: given a record of data, it returns the mapped value (computed by d3 scale function) of the specified field
- `getFormattedStringVal`: given a record of data, it returns the formatted string value (currently for the date type)

### Add `<HoverLayer>` to control the hovering information of `<DataLayer>`:
![screen shot 2019-02-11 at 6 16 22 pm](https://user-images.githubusercontent.com/1139698/52557052-4bb1ef80-2e29-11e9-8945-ace9fb29d304.png)

 `<HoverLayer>` enables us to customize the area to hover. 

It takes an array of `collisionComponents` which order corresponds to the order to the data array; If one of the children of `collisionComponents` being hovered or touched, it sets the hovering information to the `<DataLayer>`.

### Display the tooltip, the dot, and line in `<LineChart>`

If the user is currently hovering the chart, display the tooltip box with the dot and line for the data point being hovered.

## Screenshot
![screen shot 2019-02-11 at 5 45 59 pm](https://user-images.githubusercontent.com/1139698/52556553-df82bc00-2e27-11e9-9bc4-0eccf5dd4958.png)

## Changed
- Add `<HoverLayer>` to reuse the hovering interactions logic across different graphs.
- Add the tooltip and hovered effects in `<LineChart>`.
- Add the hovering information in `<DataLayer>`.
- Add `getSelectorsByField` in `<DataLayer>` to select and convert the data value in a record.

## TODOs

- [ ] Unify the way of dealing colors of the fields

