### PR TITLE
Add --project to make yarn lint script work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes simple components such as `<Foo>` and `<ResponsiveLayer>` as an experiment to see if the project settings go well. (#1)
 
 # Changed
+- Fix `yarn lint` command. (#7)
 - Upgrade React to 16.8. (#4)
 - Upgrade react-spring to the latest version which uses hooks. (#4)

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -28,7 +28,7 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint ./src"
+    "lint": "tslint --project ./src"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -28,7 +28,7 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint ./src"
+    "lint": "tslint --project ./src"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -28,7 +28,7 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint ./src"
+    "lint": "tslint --project ./src"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",


### PR DESCRIPTION
# Purpose

Make `yarn lint` really works. Before this change tslint won't work because lack of `--project` parameter.

# Change

- Add `--project` in lint script

# Risk

None.

# Todo

None.