### PR TITLE
Rewrite <HoverLayer> using Hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Extract the animation frame controls as a custom effect hook. (#10)
 - Add `tslint-react-hooks` rules to lint React Hooks. (#8)
 - Add `ThemeProvider` and color / xy axis themes config for customize theme. (#6)
 - Create an animation package, and add a simple SVG clipping animation: `<AnimatedClipRect>`. (#4)
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes simple components such as `<Foo>` and `<ResponsiveLayer>` as an experiment to see if the project settings go well. (#1)
 
 # Changed
+- Rewrite `<HoverLayer>` using Hooks. (#10)
 - Use Hooks to rewrite functionalities of `<ResponsiveLayer>`. (#8)
 - Refactor the way getting width and height in `<LineChart>`. (#8)
 - Fix `yarn lint` command. (#7)

--- a/packages/graph/src/hooks/useAnimationFrame.ts
+++ b/packages/graph/src/hooks/useAnimationFrame.ts
@@ -1,0 +1,43 @@
+import {
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react';
+
+export interface AnimationFrameControl {
+  /** The current animation frame ID */
+  animationFrame: number | null;
+
+  /** Function that takes `rafCallback` and put it into `window.requestAnimationFrame()`  */
+  requestWindowAnimationFrame: (rafCallback: () => void) => void;
+}
+
+export function useAnimationFrame(): AnimationFrameControl {
+  /** stores the animation frame ID */
+  const animaFrameIdRef = useRef<number | null>(null);
+
+  const requestWindowAnimationFrame = useCallback(
+    (rafCallback) => {
+      animaFrameIdRef.current = window.requestAnimationFrame(rafCallback);
+    },
+    [],
+  );
+
+  useEffect(
+    () => {
+      // the functional component unmounting
+      return () => {
+        // cancel the scheduled update on the animation frame
+        if (animaFrameIdRef.current) {
+          window.cancelAnimationFrame(animaFrameIdRef.current);
+        }
+      };
+    },
+    [],
+  );
+
+  return {
+    requestWindowAnimationFrame,
+    animationFrame: animaFrameIdRef.current,
+  };
+}

--- a/packages/graph/src/hooks/useContainerDimension.ts
+++ b/packages/graph/src/hooks/useContainerDimension.ts
@@ -10,6 +10,8 @@ import resizeObserverPolyfill from 'resize-observer-polyfill';
 
 import { GraphDimension } from '../common/types';
 
+import { useAnimationFrame } from './useAnimationFrame';
+
 interface ResizeObserverEntry {
   readonly target: Element;
   readonly contentRect: DOMRectReadOnly;
@@ -26,13 +28,13 @@ export function useContainerDimension(
 
   /** resizeObsrRef.current stores the ResizeObserver */
   const resizeObsrRef = useRef<ResizeObserver | null>(null);
-  /** animaFrameIDRef.current stores the current animation frame ID */
-  const animaFrameIDRef = useRef<number | null>(null);
+  /** use requestAnimationFrame to update the dimension */
+  const { requestWindowAnimationFrame } = useAnimationFrame();
 
   /** Function to set the updated dimension */
   const updateDimension = useCallback(
     (width: number, height: number) => {
-      animaFrameIDRef.current = window.requestAnimationFrame(() => {
+      requestWindowAnimationFrame(() => {
         setDimension({
           width,
           height,
@@ -69,10 +71,6 @@ export function useContainerDimension(
       resizeObsrRef.current.observe(containerRef.current!);
 
       return () => {
-        // cancel the scheduled update of the container's dimension
-        if (animaFrameIDRef.current) {
-          window.cancelAnimationFrame(animaFrameIDRef.current);
-        }
         // disconnect the resize observer on unmounted
         resizeObsrRef.current!.disconnect();
       };

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,6 +1,7 @@
 export * from './components/Foo';
 export * from './common/types';
 export * from './hooks/useContainerDimension';
+export * from './hooks/useAnimationFrame';
 export * from './layers/ResponsiveLayer';
 export * from './layers/DataLayer';
 export * from './layers/AxisLayer';

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FunctionComponent,
-  useRef,
-  useEffect,
-  useCallback,
-} from 'react';
+import React, { FunctionComponent, useCallback } from 'react';
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -7,6 +7,8 @@ import React, {
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
+import { useAnimationFrame } from '../hooks/useAnimationFrame';
+
 import { DataLayerRenderParams } from './DataLayer';
 
 export interface HoverLayerProps {
@@ -36,8 +38,8 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
   collisionComponents,
   throttleTime = 180,
 }) => {
-  /** stores the animation frame ID of the scheduled update of hovered position and data index */
-  const animaFrameIDRef = useRef<number | null>(null);
+  /** use requestAnimationFrame to schedule updates of hovered position and data index */
+  const { requestWindowAnimationFrame } = useAnimationFrame();
 
   /** Function to update the position of the tooltip and sets the currently active data index */
   const updatePosition = useCallback(
@@ -48,7 +50,7 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
 
         // convert the position of the event to the coordinate system of the SVG
         const { x, y } = localPoint(event);
-        animaFrameIDRef.current = window.requestAnimationFrame(() => {
+        requestWindowAnimationFrame(() => {
           setHoveredPosAndIndex(
             dataIndex,
             x,
@@ -77,19 +79,6 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
       // cancel the previously thorttled event to prevent the tooltip from reappearing
       updatePosition.cancel();
       clearHovering();
-    },
-    [],
-  );
-
-  // TODO: should this be extracted?
-  useEffect(
-    () => {
-      return () => {
-        // cancel the scheduled update of the container's dimension
-        if (animaFrameIDRef.current) {
-          window.cancelAnimationFrame(animaFrameIDRef.current);
-        }
-      };
     },
     [],
   );

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -1,4 +1,9 @@
-import * as React from 'react';
+import React, {
+  FunctionComponent,
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react';
 import { throttle } from 'lodash-es';
 import { localPoint } from '@vx/event';
 
@@ -14,72 +19,95 @@ export interface HoverLayerProps {
   /** Function to hide the tooltip */
   clearHovering: () => void;
 
-  /** Hidden components to detect the mouse or touch interactions */
+  /**
+   * Hidden components to detect the mouse or touch interactions.
+   * **Note:** The order of the components should correspond to the order of the data.
+   */
   collisionComponents: JSX.Element[];
 
-  /** The debounce time for the mouse and touch events */
+  /** The throttle time for the mouse and touch events */
   throttleTime: number;
 }
 
-export class HoverLayer extends React.PureComponent<HoverLayerProps, {}> {
-  public static defaultProps = {
-    throttleTime: 180,
-    handleHover: () => null,
-  };
+export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
+  setHoveredPosAndIndex,
+  handleHover= () => null,
+  clearHovering,
+  collisionComponents,
+  throttleTime = 180,
+}) => {
+  /** stores the animation frame ID of the scheduled update of hovered position and data index */
+  const animaFrameIDRef = useRef<number | null>(null);
 
-  public animaFrameID: number;
+  /** Function to update the position of the tooltip and sets the currently active data index */
+  const updatePosition = useCallback(
+    throttle(
+      (dataIndex: number, event: React.SyntheticEvent) => {
+        // custom action which executes before the position is updated
+        handleHover();
 
-  /** Updates the position of the tooltip and sets the currently active data index */
-  private updatePosition = (dataIndex: number, event: React.SyntheticEvent) => {
-    const { setHoveredPosAndIndex, handleHover } = this.props;
+        // convert the position of the event to the coordinate system of the SVG
+        const { x, y } = localPoint(event);
+        animaFrameIDRef.current = window.requestAnimationFrame(() => {
+          setHoveredPosAndIndex(
+            dataIndex,
+            x,
+            y,
+          );
+        });
+      },
+      throttleTime,
+    ),
+    [],
+  );
 
-    // custom action which executes before the position is updated
-    handleHover();
+  /** Function to keep the event data and perform throttled updates of the position */
+  const handleTooltip = useCallback(
+    (dataIndex: number) => (event: React.SyntheticEvent) => {
+      // removes it from the event pool and allows references to the event
+      event.persist();
+      updatePosition(dataIndex, event);
+    },
+    [],
+  );
 
-    // convert the position of the event to the coordinate system of the SVG
-    const { x, y } = localPoint(event);
-    this.animaFrameID = window.requestAnimationFrame(() => {
-      setHoveredPosAndIndex(
-        dataIndex,
-        x,
-        y,
-      );
+  /** Function to cancel the update of position and disable the hovering state */
+  const hideTooltip = useCallback(
+    () => {
+      // cancel the previously thorttled event to prevent the tooltip from reappearing
+      updatePosition.cancel();
+      clearHovering();
+    },
+    [],
+  );
+
+  // TODO: should this be extracted?
+  useEffect(
+    () => {
+      return () => {
+        // cancel the scheduled update of the container's dimension
+        if (animaFrameIDRef.current) {
+          window.cancelAnimationFrame(animaFrameIDRef.current);
+        }
+      };
+    },
+    [],
+  );
+
+  const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
+    const handleCurrentTooltip = handleTooltip(dataIndex);
+    return React.cloneElement(area, {
+      onTouchStart: handleCurrentTooltip,
+      onTouchMove: handleCurrentTooltip,
+      onMouseMove: handleCurrentTooltip,
+      onMouseLeave: hideTooltip,
     });
-  };
+  });
 
-  private throttledUpdatePosition = throttle(this.updatePosition, this.props.throttleTime);
-
-  private handleTooltip = (dataIndex: number) => (event: React.SyntheticEvent) => {
-    // removes it from the event pool and allows references to the event
-    event.persist();
-    this.throttledUpdatePosition(dataIndex, event);
-  };
-
-  private hideTooltip = () => {
-    // cancel the previously thorttled event to prevent the tooltip from reappearing
-    this.throttledUpdatePosition.cancel();
-    this.props.clearHovering();
-  };
-
-  public componentWillUnmount() {
-    window.cancelAnimationFrame(this.animaFrameID);
-  }
-
-  public render() {
-    const { collisionComponents } = this.props;
-    const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
-      const handleCurrentTooltip = this.handleTooltip(dataIndex);
-      return React.cloneElement(area, {
-        onTouchStart: handleCurrentTooltip,
-        onTouchMove: handleCurrentTooltip,
-        onMouseMove: handleCurrentTooltip,
-        onMouseLeave: this.hideTooltip,
-      });
-    });
-
-    return (
-      // Render areas to detect collisions of mouse pointers or touches with data points
-      detectionAreas
-    );
-  }
-}
+  // Render areas to detect collisions of mouse pointers or touches with data points
+  return (
+    <>
+      {detectionAreas}
+    </>
+  );
+};

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -60,7 +60,7 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
       },
       throttleTime,
     ),
-    [],
+    [handleHover, setHoveredPosAndIndex, throttleTime],
   );
 
   /** Function to keep the event data and perform throttled updates of the position */
@@ -70,7 +70,7 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
       event.persist();
       updatePosition(dataIndex, event);
     },
-    [],
+    [updatePosition],
   );
 
   /** Function to cancel the update of position and disable the hovering state */
@@ -80,7 +80,7 @@ export const HoverLayer: FunctionComponent<HoverLayerProps> = ({
       updatePosition.cancel();
       clearHovering();
     },
-    [],
+    [updatePosition, clearHovering],
   );
 
   const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {


### PR DESCRIPTION
# Purpose

This PR follows the rewrites using Hooks (#8, #9). It converts <HoverLayer> as a functional component.

In addition, to better reuses the process of requesting animation frame, it adds a new custom effect `useAnimationFrame` of which users can simply call its `requestWindowAnimationFrame`, and it will cancel the animation frame when the component is going to be unmounted.

# Changes

- Rewrite HoverLayer using Hooks
- Extract the animation frame controls as a custom effect hook