### PR TITLE
Add type-check watching script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add `type-check` and `type-check:watch` script in package.json. (#15)
 - Add `getColorScale` to receive color encoding in charts. (#11)
 - Extract the animation frame controls as a custom effect hook. (#10)
 - Add `tslint-react-hooks` rules to lint React Hooks. (#8)

--- a/config/tsconfig.docz.json
+++ b/config/tsconfig.docz.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "../"
+  },
+  "include": [
+    "../packages/**/*"
+  ]
+}

--- a/doczrc.js
+++ b/doczrc.js
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import ForkTSCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
 const modifyBundlerConfig = config => {
   config.resolve.alias = Object.assign({}, config.resolve.alias, {
@@ -6,6 +7,15 @@ const modifyBundlerConfig = config => {
     '@ichef/transcharts-chart': path.resolve(__dirname, 'packages/chart/src'),
     '@ichef/transcharts-animation': path.resolve(__dirname, 'packages/animation/src'),
   });
+  const customPlugins = [
+    new ForkTSCheckerWebpackPlugin({
+      tsconfig: './config/tsconfig.docz.json',
+      async: false,
+      watch: ['./packages/**/*.{ts,tsx}'],
+      tslint: true,
+    }),
+  ];
+  config.plugins.push(...customPlugins)
   return config;
 };
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "docz dev",
     "build": "docz build",
+    "type-check": "lerna run type-check --parallel --stream",
+    "type-check:watch": "lerna run type-check:watch --parallel --stream -- -- --preserveWatchOutput",
     "prepublish": "lerna run prepublish",
     "lint": "lerna run lint --parallel --stream",
     "clean": "lerna run --parallel clean"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@types/styled-components": "^4.1.6",
     "docz": "^0.13.7",
     "docz-theme-default": "^0.13.7",
+    "fork-ts-checker-webpack-plugin": "^1.0.0",
     "lerna": "^3.8.0",
     "npm-run-all": "^4.1.5",
     "prop-types": "^15.7.1",

--- a/packages/animation/index.ts
+++ b/packages/animation/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -28,7 +28,9 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint --project ./src"
+    "lint": "tslint --project ./src",
+    "type-check": "tsc -p ./src --noEmit",
+    "type-check:watch": "tsc -p ./src --noEmit --watch"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",

--- a/packages/chart/index.ts
+++ b/packages/chart/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -28,7 +28,9 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint --project ./src"
+    "lint": "tslint --project ./src",
+    "type-check": "tsc -p ./src --noEmit",
+    "type-check:watch": "tsc -p ./src --noEmit --watch"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",

--- a/packages/graph/index.ts
+++ b/packages/graph/index.ts
@@ -1,0 +1,1 @@
+export * from './src/index';

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -28,7 +28,9 @@
     "build:esm": "tsc -p ./src",
     "build:cjs": "tsc -p ./src/tsconfig.cjs.json",
     "clean": "rimraf ./dist ./lib ./es5 ./deploy",
-    "lint": "tslint --project ./src"
+    "lint": "tslint --project ./src",
+    "type-check": "tsc -p ./src --noEmit",
+    "type-check:watch": "tsc -p ./src --noEmit --watch"
   },
   "peerDependencies": {
     "prop-types": "^15.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4514,6 +4514,19 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+fork-ts-checker-webpack-plugin@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-1.0.0.tgz#0f9ff0219f9b6f1a1b10fa25d7cc5015e60c997a"
+  integrity sha512-Kc7LI0OlnWB0FRbDQO+nnDCfZr+LhFSJIP8kZppDXvuXI/opeMg3IrlMedBX/EGgOUK0ma5Hafgkdp3DuxgYdg==
+  dependencies:
+    babel-code-frame "^6.22.0"
+    chalk "^2.4.1"
+    chokidar "^2.0.4"
+    micromatch "^3.1.10"
+    minimatch "^3.0.4"
+    semver "^5.6.0"
+    tapable "^1.0.0"
+
 form-data@^2.3.2, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"


### PR DESCRIPTION
# Purpose

`docz dev` doesn't do type checking because it internally use babel to transpile `.ts` file (See [here](https://github.com/pedronauck/docz/blob/master/packages/docz-core/src/webpack/loaders.ts#L29-L44) and [there](https://github.com/pedronauck/docz/blob/master/packages/docz-core/src/webpack/loaders.ts#L71-L104)), and [babel just transpile typescript to javascript and won't check the type correctness](https://devblogs.microsoft.com/typescript/typescript-and-babel-7/). This is awkward in developing -- you believe you've done when you see it works in docz, but actually the typing is wrong.

To fix this in docz side we have to add typescript loader in docz webpack config, which is ideal but difficult. So in this PR I tried to add `type-check` and `type-check:watch` command in `package.json` to additionally do type checking in development. When we're developing just open two tabs in command line, one for `docz dev` and one for `yarn type-check:watch` so we can make sure the type is correct.

# Change

- Add `type-check` and `type-check:watch` script in package.json

# Risk

None.

# Todo

None.