### PR TITLE
Auto type checking on push with github action

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,15 @@
+workflow "Push workflow" {
+  on = "push"
+  resolves = ["type-check"]
+}
+
+action "install" {
+  uses = "borales/actions-yarn@master"
+  args = "install"
+}
+
+action "type-check" {
+  uses = "borales/actions-yarn@master"
+  needs = ["install"]
+  args = "type-check"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add Apache License. (#23)
 - Add release script. (#21)
+- Add auto type check with github action. (#20)
 - Add webpack bundle build. (#19)
 - Add `test` and `test:watch` scripts in root directory and every single package.(#17)
 - Add `jest`, `ts-jest`, `enzyme`, `enzyme-adapter-react-16` dependency.(#17)

--- a/packages/graph/src/utils/getColorScale.ts
+++ b/packages/graph/src/utils/getColorScale.ts
@@ -1,5 +1,5 @@
 import map from 'lodash/map';
-import sortedUniq from 'lodash/sortedUniq'
+import sortedUniq from 'lodash/sortedUniq';
 import { extent as d3Extent } from 'd3-array';
 import { scaleOrdinal, scaleSequential } from 'd3-scale';
 


### PR DESCRIPTION
# Purpose

It's a start to have [github action](https://github.com/features/actions) as ci tool. You could see current checking status of this PR in https://github.com/iCHEF/transcharts/pull/20/checks. It's welcome to discuss what tool we should use for automation :)

# Change

* Auto type checking on push

# Risk

Because currently there's no official github action of `yarn` so we have to use [custom github action from other prople](https://github.com/borales/actions-yarn). This may be risky if there's malicious change. It may be better if we could fork the actions so it's under our control.

# Todos

None.