### PR TITLE
Add release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add Apache License. (#23)
+- Add release script. (#21)
 - Add webpack bundle build. (#19)
 - Add `test` and `test:watch` scripts in root directory and every single package.(#17)
 - Add `jest`, `ts-jest`, `enzyme`, `enzyme-adapter-react-16` dependency.(#17)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `Transchart` is a highly customizable React data visualization library made by iCHEF.
 
 It provides:
-* Ready-to-use charts 
+* Ready-to-use charts
 * Composable `layers` to make the custom charts that suit your needs.
 
 
@@ -13,3 +13,30 @@ To install all dependencies before you start, simply run `yarn install`.
 
 To run the `docs` and start developing the graph components, use the `yarn start` script.
 
+### Releasing
+
+Steps:
+
+1. Create a release branch release/x.y.z
+
+2. (Optionally) release beta builds with yarn release:beta.
+
+3. Bump version for package.json and CHANGELOG.
+
+4. Bump children packages version with script:
+
+```
+yarn bumpversion
+```
+
+This will run `lerna version`, which updates all package.json files in packages/.
+
+5. Commit above changes, then create a pull request for this release branch.
+
+6. Once it's merged into master, run `yarn release` to manually release. (TODO: add auto release when merged into master on github)
+
+7. Backport changes from master back to develop by creating a backport/x.y.y branch and create a pull request for that.
+
+## LICENSE
+
+This project is licensed under the terms of the [Apache License 2.0](https://github.com/iCHEF/transcharts/blob/develop/LICENSE).

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,11 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.0"
+  "version": "0.0.0",
+  "npmClient": "yarn",
+  "command": {
+    "publish": {
+      "registry": "https://registry.npmjs.org"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "lint": "lerna run lint --parallel --stream",
     "clean": "lerna run --parallel clean",
     "test": "jest ./packages --config=config/jest.config.js --coverage",
-    "test:watch": "jest ./packages --watch --config=config/jest.config.js"
+    "test:watch": "jest ./packages --watch --config=config/jest.config.js",
+    "bumpversion": "lerna version --no-push --no-git-tag-version",
+    "release": "lerna publish --yes --repo-version $PACKAGE_VERSION --no-push --no-git-tag-version",
+    "release:beta": "lerna publish --no-push --no-git-tag-version --preid=beta --npm-tag=prerelease",
+    "release:canary": "lerna publish -c --yes --exact"
   },
   "devDependencies": {
     "@types/d3": "^5.7.0",
@@ -49,5 +53,8 @@
     "typescript": "^3.3.3",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.2.3"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   }
 }

--- a/packages/animation/package.json
+++ b/packages/animation/package.json
@@ -12,11 +12,9 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iCHEF/transcharts.git"
@@ -45,5 +43,6 @@
   "dependencies": {
     "d3-ease": "^1.0.5",
     "shortid": "^2.2.14"
-  }
+  },
+  "gitHead": "9c4cb286afff119b642535c7389ddc4d6d9015a1"
 }

--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -12,11 +12,9 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iCHEF/transcharts.git"
@@ -41,8 +39,9 @@
     "url": "https://github.com/iCHEF/transcharts/issues"
   },
   "dependencies": {
-    "@ichef/transcharts-graph": "^0.0.0",
+    "@ichef/transcharts-graph": "^0.0.1",
     "@vx/axis": "^0.0.183",
     "@vx/shape": "^0.0.183"
-  }
+  },
+  "gitHead": "9c4cb286afff119b642535c7389ddc4d6d9015a1"
 }

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -12,11 +12,9 @@
     "test": "__tests__"
   },
   "files": [
-    "lib"
+    "lib",
+    "dist"
   ],
-  "publishConfig": {
-    "registry": "https://registry.yarnpkg.com"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/iCHEF/transcharts.git"
@@ -52,5 +50,6 @@
     "lodash": "^4.17.11",
     "memoize-one": "^5.0.0",
     "resize-observer-polyfill": "^1.5.1"
-  }
+  },
+  "gitHead": "9c4cb286afff119b642535c7389ddc4d6d9015a1"
 }


### PR DESCRIPTION
# Purpose

Add lerna release script. It's similar to script in [gypcrete](https://github.com/iCHEF/gypcrete/blob/develop/package.json#L20-L23) except some updates on deprecated lerna option:

* `--skip-git` is deprecated now and should be replaced with `--no-push` and `--no-git-tag-version`.
([document](https://github.com/lerna/lerna/tree/master/commands/version#--skip-git))
* `--skip-npm` is deprecated now and should be replaced with `lerna version`. ([document](https://github.com/lerna/lerna/commit/cb47cb62b525196bd53b2cd523be5caa031949dd))

# Changes

- Add release script

# Risk

None.

# Todos

None.