### PR TITLE
Add vertical bar charts and vertical stacked bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add Apache License. (#23)
+- Add vertical bar charts and vertical stacked bar charts. (#22)
 - Add release script. (#21)
 - Add webpack bundle build. (#19)
 - Add `test` and `test:watch` scripts in root directory and every single package.(#17)
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove author field in package.json. (#23)
 - Replace `lodash-es` with `lodash`.(#17)
 - Remove `selectors` from `AxisScale` and `ColorScale`. (#16)
+- Allow the axes appear in the foreground. (#22)
 - Modify the config of `tslint` so that it won't continuing warning about the lack of dangling commas in functions. (#16)
 - Fix `HoverLayer` default props. (#14)
 - Fix color too light / deep with ordinal data field. (#14)

--- a/docs/charts/BarChart.mdx
+++ b/docs/charts/BarChart.mdx
@@ -112,7 +112,7 @@ You can use the same properties of multi-series line charts to create stacked ba
       y={{ type: 'quantitative', field: 'y' }}
       color={{
         field: "size",
-        type: "quantitative",
+        type: "ordinal",
       }}
     />
   </div>

--- a/docs/charts/BarChart.mdx
+++ b/docs/charts/BarChart.mdx
@@ -65,6 +65,55 @@ const lineData = [
   </div>
 </Playground>
 
+## Multiple lines
+
+### Nominal color field
+
+<Playground>
+  <div style={{ width: '100%', height: '320px' }}>
+    <BarChart
+      data={multiLinesData}
+      x={{ type: 'quantitative', field: 'x' }}
+      y={{ type: 'quantitative', field: 'y' }}
+      color={{
+        field: "type",
+        type: "nominal",
+      }}
+    />
+  </div>
+</Playground>
+
+### Quantitative color field
+
+<Playground>
+  <div style={{ width: '100%', height: '320px' }}>
+    <BarChart
+      data={[
+        { x: 1, y: 5, size: 3 },
+        { x: 3, y: 6, size: 3 },
+        { x: 2, y: 3, size: 3 },
+        { x: 9, y: 7, size: 3 },
+        { x: 7, y: 1, size: 3 },
+        { x: 4, y: 2, size: 5 },
+        { x: 1, y: 10, size: 5 },
+        { x: 6, y: 4, size: 5 },
+        { x: 8, y: 9, size: 5 },
+        { x: 9, y: 0, size: 5 },
+        { x: 5, y: 3, size: 8 },
+        { x: 3, y: 8, size: 8 },
+        { x: 4, y: 4, size: 8 },
+        { x: 10, y:7, size: 8 },
+      ]}
+      x={{ type: 'quantitative', field: 'x' }}
+      y={{ type: 'quantitative', field: 'y' }}
+      color={{
+        field: "size",
+        type: "quantitative",
+      }}
+    />
+  </div>
+</Playground>
+
 ## Props
 
 <PropsTable of={BarChart} />

--- a/docs/charts/BarChart.mdx
+++ b/docs/charts/BarChart.mdx
@@ -65,9 +65,11 @@ const lineData = [
   </div>
 </Playground>
 
-## Multiple lines
+## Stacked bar chart
 
 ### Nominal color field
+
+You can use the same properties of multi-series line charts to create stacked bar charts.
 
 <Playground>
   <div style={{ width: '100%', height: '320px' }}>

--- a/docs/charts/BarChart.mdx
+++ b/docs/charts/BarChart.mdx
@@ -1,0 +1,70 @@
+---
+name: Bar Chart
+route: /charts/bar_chart
+menu: Charts
+---
+
+import { Playground, PropsTable } from 'docz'
+import { BarChart } from '@ichef/transcharts-chart'
+import lineData from '../sampleData/lineData';
+import multiLinesData from '../sampleData/multiLinesData'
+
+# Bar Chart
+
+The `<BarChart>` component supports drawing bars.
+
+We use the following example data to generate the example charts below.
+
+**Example Data:**
+
+```js
+const lineData = [
+  { x: 0, y: 9, date: '2019/01/21 00:00:00', weekday: 'Mon' },
+  { x: 1, y: 5, date: '2019/01/22 00:00:00', weekday: 'Tue' },
+  { x: 2, y: 5, date: '2019/01/23 00:00:00', weekday: 'Wed' },
+  { x: 3, y: 3, date: '2019/01/24 00:00:00', weekday: 'Thu'},
+  { x: 4, y: 1, date: '2019/01/25 00:00:00', weekday: 'Fri' },
+];
+```
+
+## Using different scales on the X-axis
+
+### Linear + Linear
+
+<Playground>
+  <div style={{ width: '100%', height: '320px' }}>
+    <BarChart
+      data={lineData}
+      x={{ field: 'x', type: 'quantitative', scale: 'linear' }}
+      y={{ field: 'y', type: 'quantitative', scale: 'linear' }}
+    />
+  </div>
+</Playground>
+
+### Time + Linear
+
+<Playground>
+  <div style={{ width: '100%', height: '320px' }}>
+    <BarChart
+      data={lineData}
+      x={{ field: 'date', type: 'quantitative', scale: 'time' }}
+      y={{ field: 'x', type: 'quantitative', scale: 'linear' }}
+    />
+  </div>
+</Playground>
+
+### Point + Linear
+
+<Playground>
+  <div style={{ width: '100%', height: '320px' }}>
+    <BarChart
+      data={lineData}
+      x={{ field: 'weekday', type: 'quantitative', scale: 'point' }}
+      y={{ field: 'y', type: 'quantitative', scale: 'linear' }}
+    />
+  </div>
+</Playground>
+
+## Props
+
+<PropsTable of={BarChart} />

--- a/docs/charts/BarChart.mdx
+++ b/docs/charts/BarChart.mdx
@@ -92,11 +92,13 @@ You can use the same properties of multi-series line charts to create stacked ba
     <BarChart
       data={[
         { x: 1, y: 5, size: 3 },
-        { x: 3, y: 6, size: 3 },
-        { x: 2, y: 3, size: 3 },
+        { x: 3, y: -7, size: 3 },
+        { x: 3, y: -3, size: 5 },
+        { x: 3, y: -5, size: 8 },
         { x: 9, y: 7, size: 3 },
         { x: 7, y: 1, size: 3 },
-        { x: 4, y: 2, size: 5 },
+        { x: 7, y: -5, size: 4 },
+        { x: 4, y: -2, size: 5 },
         { x: 1, y: 10, size: 5 },
         { x: 6, y: 4, size: 5 },
         { x: 8, y: 9, size: 5 },
@@ -104,7 +106,7 @@ You can use the same properties of multi-series line charts to create stacked ba
         { x: 5, y: 3, size: 8 },
         { x: 3, y: 8, size: 8 },
         { x: 4, y: 4, size: 8 },
-        { x: 10, y:7, size: 8 },
+        { x: 10, y: 7, size: 8 },
       ]}
       x={{ type: 'quantitative', field: 'x' }}
       y={{ type: 'quantitative', field: 'y' }}

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -193,7 +193,7 @@ export const BarChart = ({
         setHoveredPosAndIndex={setHoveredPosAndIndex}
         clearHovering={clearHovering}
         collisionComponents={data.map(
-          (dataRow, idx) => {
+          (_, idx) => {
             return (
               <rect
                 // #TODO: use unique keys rather than array index

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -18,6 +18,7 @@ import {
 import { useChartDimensions } from '../hooks/useChartDimensions';
 import { useCartesianEncodings } from '../hooks/useCartesianEncodings';
 import { SvgWithAxisFrame } from '../frames/SvgWithAxisFrame';
+import { DEFAULT_VALS } from '../common/config';
 
 /** A line and a dot for the point being hovered */
 const HoveringIndicator: FunctionComponent<{
@@ -53,7 +54,7 @@ export interface BarChartProps {
   /** Should show the axis on the bottom or not */
   showBottomAxis?: boolean;
 
-  /** Ration of the paddings between bars */
+  /** Ratio of the paddings between bars */
   paddingInner: number;
 
   data: object[];
@@ -61,6 +62,11 @@ export interface BarChartProps {
   y: AxisEncoding;
   color?: ColorEncoding;
 }
+
+const defaultProps = {
+  margin: DEFAULT_VALS.MARGIN,
+  paddingInner: 0.1,
+};
 
 export const BarChart = ({
   data,
@@ -208,3 +214,4 @@ export const BarChart = ({
     </SvgWithAxisFrame>
   );
 };
+BarChart.defaultProps = defaultProps;

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent, useContext, useMemo, useCallback } from 'react';
+import { ScaleBand } from 'd3-scale';
 import {
   // from HoverLayer
   HoverLayer,
@@ -99,7 +100,8 @@ export const BarChart = ({
   } = useCartesianEncodings(graphDimension, theme, data, xEncoding, yEncoding, color);
   const { clearHovering, hovering, hoveredPoint, setHoveredPosAndIndex } = useHoverState();
 
-  const bandWidth = scalesConfig.x.scale.bandwidth();
+  const bandScale = scalesConfig.x.scale as ScaleBand<any>;
+  const bandWidth = bandScale.bandwidth();
 
   /**
    * Returns the size and position of the collision rectangle or hovering highlight rectangle

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -56,15 +56,15 @@ export const BarChart = ({
   const { chartRef, outerDimension, graphDimension } = useChartDimensions(margin);
   const { width: graphWidth, height: graphHeight } = graphDimension;
 
-  const xBand: AxisEncoding = { ...x, scale: 'band', scaleConfig: {
+  const xEncoding: AxisEncoding = { ...x, scale: 'band', scaleConfig: {
     paddingInner: 0.1,
   }};
-  const yBand: AxisEncoding = { ...y, scale: 'linear' };
+  const yEncoding: AxisEncoding = { ...y, scale: 'linear' };
   const {
     dataGroups,
     scalesConfig,
     rowValSelectors,
-  } = useCartesianEncodings(graphDimension, theme, data, xBand, yBand, color);
+  } = useCartesianEncodings(graphDimension, theme, data, xEncoding, yEncoding, color);
 
   const graphGroup = dataGroups.map(
     (rows: object[], groupIdx: number) => {

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -1,0 +1,101 @@
+import React, { FunctionComponent, useContext } from 'react';
+import { LinePath } from '@vx/shape';
+import {
+  // from HoverLayer
+  HoverLayer,
+  // from hooks
+  useHoverState,
+  // from TooltipLayer
+  TooltipLayer,
+  // from common types
+  Margin,
+  FieldSelector,
+  AxisEncoding,
+  ColorEncoding,
+  // from themes
+  Theme,
+  ThemeContext,
+} from '@ichef/transcharts-graph';
+
+import { useChartDimensions } from '../hooks/useChartDimensions';
+import { useCartesianEncodings } from '../hooks/useCartesianEncodings';
+import { SvgWithAxisFrame } from '../frames/SvgWithAxisFrame';
+
+export interface BarChartProps {
+  /** Margin between the inner graph area and the outer svg */
+  margin?: Margin;
+
+  /** Should show the axis on the left or not */
+  showLeftAxis?: boolean;
+
+  /** Should show the axis on the bottom or not */
+  showBottomAxis?: boolean;
+
+  data: object[];
+  x: AxisEncoding;
+  y: AxisEncoding;
+  color?: ColorEncoding;
+}
+
+export const BarChart = ({
+  data,
+  // FIXME: remove the default margin after fixing the defaultProps of`<SvgWithAxisFrame>`
+  margin = {
+    top: 20,
+    right: 20,
+    bottom: 30,
+    left: 60,
+  },
+  x,
+  y,
+  color,
+  showLeftAxis,
+  showBottomAxis,
+}: BarChartProps) => {
+  const theme = useContext<Theme>(ThemeContext);
+  const { chartRef, outerDimension, graphDimension } = useChartDimensions(margin);
+  const { width: graphWidth, height: graphHeight } = graphDimension;
+
+  // TODO: 1. add padding the scaleBand
+  const xBand: AxisEncoding = { ...x, scale: 'band' };
+  const yBand: AxisEncoding = { ...y, scale: 'linear' };
+  const {
+    dataGroups,
+    scalesConfig,
+    rowValSelectors,
+  } = useCartesianEncodings(graphDimension, theme, data, xBand, yBand, color);
+
+  const graphGroup = dataGroups.map(
+    (rows: object[], groupIdx: number) => {
+      return rows.map((row: object, rowIdx: number) => {
+        const colorString: string = rowValSelectors.color.getString(rows[0]);
+        return (
+          <rect
+            key={`bar-${rowIdx}`}
+            x={rowValSelectors.x.getScaledVal(row)}
+            y={rowValSelectors.y.getScaledVal(row)}
+            width={scalesConfig.x.scale.bandwidth()}
+            height={graphHeight - rowValSelectors.y.getScaledVal(row)}
+            fill={colorString}
+          />
+        );
+      });
+      console.log(rows, colorString)
+    }
+  );
+
+  return (
+    <SvgWithAxisFrame
+      ref={chartRef}
+      outerDimension={outerDimension}
+      graphDimension={graphDimension}
+      showLeftAxis={showLeftAxis}
+      showBottomAxis={showBottomAxis}
+      margin={margin}
+      data={data}
+      scalesConfig={scalesConfig}
+    >
+      {graphGroup}
+    </SvgWithAxisFrame>
+  );
+};

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -56,8 +56,9 @@ export const BarChart = ({
   const { chartRef, outerDimension, graphDimension } = useChartDimensions(margin);
   const { width: graphWidth, height: graphHeight } = graphDimension;
 
-  // TODO: 1. add padding the scaleBand
-  const xBand: AxisEncoding = { ...x, scale: 'band' };
+  const xBand: AxisEncoding = { ...x, scale: 'band', scaleConfig: {
+    paddingInner: 0.1,
+  }};
   const yBand: AxisEncoding = { ...y, scale: 'linear' };
   const {
     dataGroups,

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -93,7 +93,6 @@ export const BarChart = ({
           />
         );
       });
-      console.log(rows, colorString)
     }
   );
 
@@ -104,6 +103,8 @@ export const BarChart = ({
       graphDimension={graphDimension}
       showLeftAxis={showLeftAxis}
       showBottomAxis={showBottomAxis}
+      // put the axes on top of the bars
+      axisInBackground={false}
       margin={margin}
       data={data}
       scalesConfig={scalesConfig}

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext } from 'react';
+import React, { FunctionComponent, useContext, useMemo } from 'react';
 import { LinePath } from '@vx/shape';
 import {
   // from HoverLayer
@@ -66,34 +66,40 @@ export const BarChart = ({
     rowValSelectors,
   } = useCartesianEncodings(graphDimension, theme, data, xEncoding, yEncoding, color);
 
-  const accumY = {};
-  const getAccumY = (xPos: number, yPos: number, height: number) => {
-    if (!accumY[xPos]) {
-      accumY[xPos] = graphHeight;
-    }
-    accumY[xPos] -= height;
-    return accumY[xPos];
-  };
+  const graphGroup = useMemo(
+    () => {
+      // calculate the accumulated y position of certain points
+      const accumY = {};
+      const getAccumY = (xPos: number, yPos: number, height: number) => {
+        if (!accumY[xPos]) {
+          accumY[xPos] = graphHeight;
+        }
+        accumY[xPos] -= height;
+        return accumY[xPos];
+      };
 
-  const graphGroup = dataGroups.map(
-    (rows: object[], groupIdx: number) => {
-      return rows.map((row: object, rowIdx: number) => {
-        const colorString: string = rowValSelectors.color.getString(rows[0]);
-        const xPos = rowValSelectors.x.getScaledVal(row);
-        const yPos = rowValSelectors.y.getScaledVal(row);
-        const height = graphHeight - yPos;
-        return (
-          <rect
-            key={`bar-${rowIdx}`}
-            x={xPos}
-            y={getAccumY(xPos, yPos, height)}
-            width={scalesConfig.x.scale.bandwidth()}
-            height={height}
-            fill={colorString}
-          />
-        );
-      });
-    }
+      return dataGroups.map(
+        (rows: object[], groupIdx: number) => {
+          return rows.map((row: object, rowIdx: number) => {
+            const colorString: string = rowValSelectors.color.getString(rows[0]);
+            const xPos = rowValSelectors.x.getScaledVal(row);
+            const yPos = rowValSelectors.y.getScaledVal(row);
+            const height = graphHeight - yPos;
+            return (
+              <rect
+                key={`bar-${rowIdx}`}
+                x={xPos}
+                y={getAccumY(xPos, yPos, height)}
+                width={scalesConfig.x.scale.bandwidth()}
+                height={height}
+                fill={colorString}
+              />
+            );
+          });
+        }
+      );
+    },
+    [dataGroups, scalesConfig, rowValSelectors],
   );
 
   return (

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -66,17 +66,29 @@ export const BarChart = ({
     rowValSelectors,
   } = useCartesianEncodings(graphDimension, theme, data, xEncoding, yEncoding, color);
 
+  const accumY = {};
+  const getAccumY = (xPos: number, yPos: number, height: number) => {
+    if (!accumY[xPos]) {
+      accumY[xPos] = graphHeight;
+    }
+    accumY[xPos] -= height;
+    return accumY[xPos];
+  };
+
   const graphGroup = dataGroups.map(
     (rows: object[], groupIdx: number) => {
       return rows.map((row: object, rowIdx: number) => {
         const colorString: string = rowValSelectors.color.getString(rows[0]);
+        const xPos = rowValSelectors.x.getScaledVal(row);
+        const yPos = rowValSelectors.y.getScaledVal(row);
+        const height = graphHeight - yPos;
         return (
           <rect
             key={`bar-${rowIdx}`}
-            x={rowValSelectors.x.getScaledVal(row)}
-            y={rowValSelectors.y.getScaledVal(row)}
+            x={xPos}
+            y={getAccumY(xPos, yPos, height)}
             width={scalesConfig.x.scale.bandwidth()}
-            height={graphHeight - rowValSelectors.y.getScaledVal(row)}
+            height={height}
             fill={colorString}
           />
         );

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -7,6 +7,8 @@ import {
   useHoverState,
   // from TooltipLayer
   TooltipLayer,
+  // from Legend,
+  LegendGroup,
   // from common types
   Margin,
   AxisEncoding,
@@ -86,7 +88,7 @@ export const BarChart = ({
   paddingInner = 0.1,
 }: BarChartProps) => {
   const theme = useContext<Theme>(ThemeContext);
-  const { chartRef, outerDimension, graphDimension } = useChartDimensions(margin);
+  const { chartRef, legendRef, outerDimension, graphDimension } = useChartDimensions(margin);
   const { width: graphWidth, height: graphHeight } = graphDimension;
 
   const xEncoding: AxisEncoding = { ...x, scale: 'band', scaleConfig: {
@@ -175,19 +177,29 @@ export const BarChart = ({
       data={data}
       scalesConfig={scalesConfig}
       svgOverlay={
-        // Draw the tooltip
-        <TooltipLayer
-          hovering={hovering}
-          hoveredPoint={hoveredPoint}
-          data={data}
-          graphWidth={graphWidth}
-          graphHeight={graphHeight}
-          margin={margin}
-          xSelector={rowValSelectors.x}
-          ySelector={rowValSelectors.y}
-          x={rowValSelectors.x.getScaledVal(data[hoveredPoint.index]) + bandWidth / 2}
-          getColor={rowValSelectors.color.getString}
-        />
+        <>
+          {/* Draw the tooltip */}
+          <TooltipLayer
+            hovering={hovering}
+            hoveredPoint={hoveredPoint}
+            data={data}
+            graphWidth={graphWidth}
+            graphHeight={graphHeight}
+            margin={margin}
+            xSelector={rowValSelectors.x}
+            ySelector={rowValSelectors.y}
+            x={rowValSelectors.x.getScaledVal(data[hoveredPoint.index]) + bandWidth / 2}
+            getColor={rowValSelectors.color.getString}
+          />
+          {/* Draw the legned */}
+          <LegendGroup
+            color={color && {
+              ...color,
+              ...scalesConfig.color!,
+            }}
+            ref={legendRef}
+          />
+        </>
       }
     >
       {graphGroup}

--- a/packages/chart/src/frames/SvgWithAxisFrame.tsx
+++ b/packages/chart/src/frames/SvgWithAxisFrame.tsx
@@ -82,9 +82,7 @@ const FrameContent = ({
     <>
       <svg width={outerWidth} height={outerHeight}>
         <g transform={`translate(${margin.left}, ${margin.top})`}>
-          {
-            axisInBackground ? [axisLayer, children] : [children, axisLayer]
-          }
+          {axisInBackground ? (<>{axisLayer}{children}</>) : (<>{children}{axisLayer}</>)}
         </g>
       </svg>
       {svgOverlay}

--- a/packages/chart/src/frames/SvgWithAxisFrame.tsx
+++ b/packages/chart/src/frames/SvgWithAxisFrame.tsx
@@ -31,6 +31,9 @@ export interface SvgFrameProps {
   /** Should show the axis on the bottom or not */
   showBottomAxis: boolean;
 
+  /** Whether to display the axes in the background or foreground of the chart */
+  axisInBackground: boolean;
+
   scalesConfig: {
     x: AxisScale,
     y: AxisScale,
@@ -46,6 +49,7 @@ export interface SvgFrameProps {
 const defaultProps = {
   showLeftAxis: true,
   showBottomAxis: true,
+  axisInBackground: true,
 };
 
 const FrameContent = ({
@@ -56,26 +60,31 @@ const FrameContent = ({
   scalesConfig,
   showLeftAxis,
   showBottomAxis,
+  axisInBackground,
   svgOverlay,
   children,
 }: SvgFrameProps) => {
   const { width: outerWidth, height: outerHeight } = outerDimension;
   const { width: graphWidth, height: graphHeight } = graphDimension;
+  const axisLayer = (
+    <AxisLayer
+      width={graphWidth}
+      height={graphHeight}
+      showLeftAxis={showLeftAxis}
+      showBottomAxis={showBottomAxis}
+      data={data}
+      xAxis={scalesConfig.x}
+      yAxis={scalesConfig.y}
+    />
+  );
 
   return (
     <>
       <svg width={outerWidth} height={outerHeight}>
         <g transform={`translate(${margin.left}, ${margin.top})`}>
-          <AxisLayer
-            width={graphWidth}
-            height={graphHeight}
-            showLeftAxis={showLeftAxis}
-            showBottomAxis={showBottomAxis}
-            data={data}
-            xAxis={scalesConfig.x}
-            yAxis={scalesConfig.y}
-          />
-          {children}
+          {
+            axisInBackground ? [axisLayer, children] : [children, axisLayer]
+          }
         </g>
       </svg>
       {svgOverlay}

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -20,7 +20,7 @@ import {
 /**
  * Return [min, max] of a column selected from the grouped data
  */
-function getRangeFromDataGroup(
+function getDomainFromDataGroup(
   dataGroups: object[][],
   keyField: string,
   valueField: string,
@@ -102,7 +102,7 @@ export const useCartesianEncodings = (
 
       // update the domain if the domains of x-y scales is band-linear
       if (x.scale === 'linear' && y.scale === 'band') {
-        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, y.field, x.field));
+        axisScale.scale.domain(getDomainFromDataGroup(dataGroups, y.field, x.field));
       }
       return axisScale;
     },
@@ -118,7 +118,7 @@ export const useCartesianEncodings = (
 
       // update the domain if the domains of x-y scales is linear-band
       if (x.scale === 'band' && y.scale === 'linear') {
-        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, x.field, y.field));
+        axisScale.scale.domain(getDomainFromDataGroup(dataGroups, x.field, y.field));
       }
       return axisScale;
     },

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import values from 'lodash/values';
 import {
   // from utils
   getColorScale,
@@ -24,20 +25,28 @@ function getDomainFromDataGroup(
   keyField: string,
   valueField: string,
 ) {
-  const aggreated = {};
+  const aggreatedMax: object = {};
+  const aggreatedMin: object = {};
   dataGroups.forEach((data: object[]) => {
     data.forEach((row) => {
       const key = row[keyField];
       const val = row[valueField];
-      aggreated[key] = aggreated[key]
-        ? aggreated[key] + val
-        : val;
+      if (val >= 0) {
+        aggreatedMax[key] = aggreatedMax[key]
+          ? aggreatedMax[key] + val
+          : val;
+      } else {
+        aggreatedMin[key] = aggreatedMin[key]
+          ? aggreatedMin[key] + val
+          : val;
+      }
     });
   });
 
-  const max = Math.max(...Object.keys(aggreated).map(key => aggreated[key]));
+  const min = Math.min(0, ...values(aggreatedMin));
+  const max = Math.max(0, ...values(aggreatedMax));
 
-  return [0, max];
+  return [min, max];
 }
 
 /**

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -20,7 +20,7 @@ import {
 /**
  * Return [min, max] of a column selected from the grouped data
  */
-function getDomainFromDataGroup(
+function getLinearDomainFromDataGroup(
   dataGroups: object[][],
   keyField: string,
   valueField: string,
@@ -110,7 +110,7 @@ export const useCartesianEncodings = (
 
       // update the domain if the domains of x-y scales is band-linear
       if (x.scale === 'linear' && y.scale === 'band') {
-        axisScale.scale.domain(getDomainFromDataGroup(dataGroups, y.field, x.field));
+        axisScale.scale.domain(getLinearDomainFromDataGroup(dataGroups, y.field, x.field));
       }
       return axisScale;
     },
@@ -126,7 +126,7 @@ export const useCartesianEncodings = (
 
       // update the domain if the domains of x-y scales is linear-band
       if (x.scale === 'band' && y.scale === 'linear') {
-        axisScale.scale.domain(getDomainFromDataGroup(dataGroups, x.field, y.field));
+        axisScale.scale.domain(getLinearDomainFromDataGroup(dataGroups, x.field, y.field));
       }
       return axisScale;
     },

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -11,7 +11,6 @@ import {
   Encoding,
   AxisEncoding,
   ColorEncoding,
-  AxisScale,
   GraphDimension,
   // from themes
   Theme,
@@ -70,7 +69,7 @@ export const useCartesianEncodings = (
   // sort the data
   const sortedData = useMemo(
     () => {
-      const getValue = getValByScaleType(x.scaleType);
+      const getValue = getValByScaleType(x.scale);
       const getOriginalVal = (record: object) => getValue(record[x.field]);
 
       return (
@@ -92,7 +91,7 @@ export const useCartesianEncodings = (
   );
 
   // the scales and configs of the axis based on its encodings
-  const xAxis: AxisScale = useMemo(
+  const xAxis = useMemo(
     () => {
       const axisScale = getXAxisScale({
         data,
@@ -108,7 +107,7 @@ export const useCartesianEncodings = (
     },
     [data, width, x],
   );
-  const yAxis: AxisScale = useMemo(
+  const yAxis = useMemo(
     () => {
       const axisScale = getYAxisScale({
         data,

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -7,7 +7,6 @@ import {
   getYAxisScale,
   getRecordFieldSelector,
   getValByScaleType,
-  getFieldValuesFromData,
   // from common types
   Encoding,
   AxisEncoding,
@@ -23,16 +22,23 @@ import {
  */
 function getRangeFromDataGroup(
   dataGroups: object[][],
-  fieldName: string,
+  keyField: string,
+  valueField: string,
 ) {
-  const min: number = Math.min(...getFieldValuesFromData(dataGroups[0], fieldName));
-  let max = min;
-  dataGroups.forEach((group: object[]) => {
-    const values = getFieldValuesFromData(group, fieldName);
-    max += (Math.max(...values) - Math.min(...values));
+  const aggreated = {};
+  dataGroups.forEach((data: object[]) => {
+    data.forEach((row) => {
+      const key = row[keyField];
+      const val = row[valueField];
+      aggreated[key] = aggreated[key]
+        ? aggreated[key] + val
+        : val;
+    });
   });
 
-  return [min, max];
+  const max = Math.max(...Object.keys(aggreated).map(key => aggreated[key]));
+
+  return [0, max];
 }
 
 /**
@@ -95,8 +101,8 @@ export const useCartesianEncodings = (
       });
 
       // update the domain if the domains of x-y scales is band-linear
-      if (dataGroups.length > 1 && (x.scale === 'linear' && y.scale === 'band')) {
-        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, x.field));
+      if (x.scale === 'linear' && y.scale === 'band') {
+        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, y.field, x.field));
       }
       return axisScale;
     },
@@ -111,8 +117,8 @@ export const useCartesianEncodings = (
       });
 
       // update the domain if the domains of x-y scales is linear-band
-      if (dataGroups.length > 1 && (x.scale === 'band' && y.scale === 'linear')) {
-        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, y.field));
+      if (x.scale === 'band' && y.scale === 'linear') {
+        axisScale.scale.domain(getRangeFromDataGroup(dataGroups, x.field, y.field));
       }
       return axisScale;
     },

--- a/packages/chart/src/index.ts
+++ b/packages/chart/src/index.ts
@@ -2,5 +2,6 @@ export * from './common/config';
 export * from './hooks/useChartDimensions';
 export * from './hooks/useCartesianEncodings';
 export * from './line/LineChart';
+export * from './bar/BarChart';
 export * from './frames/SvgWithAxisFrame';
 export * from './utils/getInnerGraphDimensionAndMargin';

--- a/packages/graph/src/common/config.ts
+++ b/packages/graph/src/common/config.ts
@@ -1,0 +1,7 @@
+import { ScaleType } from './types';
+
+const SCALE_TYPE: ScaleType = 'linear';
+
+export const DEFAULT_VALS = {
+  SCALE_TYPE,
+};

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -2,6 +2,7 @@ import {
   ScaleLinear,
   ScalePoint,
   ScaleTime,
+  ScaleBand,
 } from 'd3-scale';
 
 export interface FieldSelector {
@@ -40,11 +41,14 @@ export interface Scale {
   getValue: (val: any) => any;
 }
 
-export type AxisScaleType = 'point' | 'time' | 'linear';
+export type AxisScaleType = 'point' | 'time' | 'linear' | 'band';
 
 export interface AxisScale extends Scale {
   /** d3's Scaling function employed in this axis */
-  scale: ScalePoint<any> | ScaleTime<any, any> | ScaleLinear<any, any>; // d3 scale function
+  scale: ScalePoint<any>
+    | ScaleTime<any, any>
+    | ScaleLinear<any, any>
+    | ScaleBand<any>; // d3 scale function
 
   /** scale type string */
   scaleType: AxisScaleType;

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -69,6 +69,13 @@ export interface Encoding {
   field: string;
   type: EncodingDataType;
   scale?: string;
+
+  /** Extra configurations to generate D3 scale */
+  scaleConfig?: {
+    padding?: number;
+    paddingInner?: number;
+    paddingOuter?: number;
+  };
 }
 
 export interface AxisEncoding extends Encoding {

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -16,12 +16,14 @@ export interface GraphDimension {
   height: number;
 }
 
+export type ScaleType = 'point' | 'time' | 'linear' | 'band' | 'color';
+
 export interface Scale {
   /** d3's Scaling function employed in specific channel */
   scale: (...values: any[]) => any;
 
   /** scale type string */
-  scaleType: string;
+  scaleType: ScaleType;
 
   /** field for axis */
   field: string;
@@ -36,12 +38,7 @@ export interface Scale {
    * Range of input channel
    */
   range?: ReadonlyArray<any>;
-
-  /** Returns the formatted value according to the type of the axis */
-  getValue: (val: any) => any;
 }
-
-export type AxisScaleType = 'point' | 'time' | 'linear' | 'band';
 
 export interface AxisScale extends Scale {
   /** d3's Scaling function employed in this axis */
@@ -49,9 +46,6 @@ export interface AxisScale extends Scale {
     | ScaleTime<any, any>
     | ScaleLinear<any, any>
     | ScaleBand<any>; // d3 scale function
-
-  /** scale type string */
-  scaleType: AxisScaleType;
 
   /**
    * Range of the axis: [min, max]
@@ -79,7 +73,7 @@ export interface Encoding {
 }
 
 export interface AxisEncoding extends Encoding {
-  scale?: AxisScaleType;
+  scale?: ScaleType;
 }
 
 export interface LegendConfig {

--- a/packages/graph/src/common/types.ts
+++ b/packages/graph/src/common/types.ts
@@ -16,7 +16,12 @@ export interface GraphDimension {
   height: number;
 }
 
-export type ScaleType = 'point' | 'time' | 'linear' | 'band' | 'color';
+export type ScaleType = 'point'
+| 'time'
+| 'linear'
+| 'band'
+| 'ordinal'
+| 'sequential';
 
 export interface Scale {
   /** d3's Scaling function employed in specific channel */

--- a/packages/graph/src/hooks/useHoverState.ts
+++ b/packages/graph/src/hooks/useHoverState.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 
 import { HoveredPointState, HoveringState } from '../common/types';
 
@@ -27,20 +27,26 @@ export function useHoverState(): HoverStateControls {
     },
   });
 
-  const clearHovering = () => {
-    setHovering(false);
-  };
+  const clearHovering = useCallback(
+    () => {
+      setHovering(false);
+    },
+    [],
+  );
 
-  const setHoveredPosAndIndex = (hoveredIndex: number, xPos: number, yPos: number) => {
-    setHovering(true);
-    setHoveredPoint({
-      index: hoveredIndex,
-      position: {
-        x: xPos,
-        y: yPos,
-      },
-    });
-  };
+  const setHoveredPosAndIndex = useCallback(
+    (hoveredIndex: number, xPos: number, yPos: number) => {
+      setHovering(true);
+      setHoveredPoint({
+        index: hoveredIndex,
+        position: {
+          x: xPos,
+          y: yPos,
+        },
+      });
+    },
+    [],
+  );
 
   return {
     hovering,

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -18,3 +18,4 @@ export * from './utils/getAxisScale';
 export * from './utils/getColorScale';
 export * from './utils/getDataGroupByEncodings';
 export * from './utils/getRecordFieldSelector';
+export * from './utils/getFieldValuesFromData';

--- a/packages/graph/src/index.ts
+++ b/packages/graph/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/Foo';
 export * from './common/types';
+export * from './common/config';
 export * from './hooks/useContainerDimension';
 export * from './hooks/useHoverState';
 export * from './hooks/useAnimationFrame';
@@ -12,6 +13,7 @@ export * from './legend/Legend';
 export * from './legend/LegendGroup';
 export * from './tooltip/Tooltip';
 export * from './tooltip/TooltipItem';
+export * from './utils/getValByScaleType';
 export * from './utils/getAxisScale';
 export * from './utils/getColorScale';
 export * from './utils/getDataGroupByEncodings';

--- a/packages/graph/src/layers/AxisLayer.tsx
+++ b/packages/graph/src/layers/AxisLayer.tsx
@@ -62,7 +62,7 @@ const getYtickLabelProps = (styles: {
 /**
  * Always format the value as string to prevent the zero value from not showing
  */
-const tickForat = (val: any) => `${val}`;
+const tickFormat = (val: any) => `${val}`;
 
 export const AxisLayer: React.SFC<AxisLayerProps> = ({
   width,
@@ -93,7 +93,7 @@ export const AxisLayer: React.SFC<AxisLayerProps> = ({
             // TODO: modify it as a function
             numTicks={getNumberOfTicks(height, data)}
             tickLabelProps={getXtickLabelProps(xAxisTheme)}
-            tickFormat={tickForat}
+            tickFormat={tickFormat}
             // TODO: format the ticks based on the axis types
             // tickComponent={({ formattedValue, ...tickProps }) => (
             //   <text {...tickProps}>{formattedValue}</text>
@@ -109,7 +109,7 @@ export const AxisLayer: React.SFC<AxisLayerProps> = ({
             tickStroke={yAxisTheme.tickStrokeColor}
             numTicks={getNumberOfTicks(width, data)}
             label="label"
-            tickFormat={tickForat}
+            tickFormat={tickFormat}
             tickLabelProps={getYtickLabelProps(yAxisTheme)}
           />
         )}

--- a/packages/graph/src/layers/AxisLayer.tsx
+++ b/packages/graph/src/layers/AxisLayer.tsx
@@ -59,6 +59,11 @@ const getYtickLabelProps = (styles: {
   textAnchor: 'middle',
 });
 
+/**
+ * Always format the value as string to prevent the zero value from not showing
+ */
+const tickForat = (val: any) => `${val}`;
+
 export const AxisLayer: React.SFC<AxisLayerProps> = ({
   width,
   height,
@@ -88,6 +93,7 @@ export const AxisLayer: React.SFC<AxisLayerProps> = ({
             // TODO: modify it as a function
             numTicks={getNumberOfTicks(height, data)}
             tickLabelProps={getXtickLabelProps(xAxisTheme)}
+            tickFormat={tickForat}
             // TODO: format the ticks based on the axis types
             // tickComponent={({ formattedValue, ...tickProps }) => (
             //   <text {...tickProps}>{formattedValue}</text>
@@ -102,7 +108,8 @@ export const AxisLayer: React.SFC<AxisLayerProps> = ({
             strokeWidth={yAxisTheme.strokeWidth}
             tickStroke={yAxisTheme.tickStrokeColor}
             numTicks={getNumberOfTicks(width, data)}
-            // TODO: deal with date type
+            label="label"
+            tickFormat={tickForat}
             tickLabelProps={getYtickLabelProps(yAxisTheme)}
           />
         )}

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -15,16 +15,16 @@ export interface TooltipLayerProps {
   ySelector: FieldSelector;
 
   /** X position of the tooltip */
-  x: number;
+  x?: number;
 
   /** Y position of the tooltip */
-  y: number;
+  y?: number;
 
   getColor: FieldSelector['getScaledVal'];
 }
 
 /** Generates the tooltip box */
-export const TooltipLayer: React.FC<TooltipLayerProps> = ({
+export const TooltipLayer = ({
   hovering,
   hoveredPoint,
   data,
@@ -36,7 +36,7 @@ export const TooltipLayer: React.FC<TooltipLayerProps> = ({
   x = xSelector.getScaledVal(data[hoveredPoint.index]),
   y = hoveredPoint.position.y,
   getColor,
-}) => {
+}: TooltipLayerProps) => {
   const { index } = hoveredPoint;
 
   return (

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -13,6 +13,13 @@ export interface TooltipLayerProps {
   margin: Margin;
   xSelector: FieldSelector;
   ySelector: FieldSelector;
+
+  /** X position of the tooltip */
+  x: number;
+
+  /** Y position of the tooltip */
+  y: number;
+
   getColor: FieldSelector['getScaledVal'];
 }
 
@@ -26,9 +33,11 @@ export const TooltipLayer: React.FC<TooltipLayerProps> = ({
   margin,
   xSelector,
   ySelector,
+  x = xSelector.getScaledVal(data[hoveredPoint.index]),
+  y = hoveredPoint.position.y,
   getColor,
 }) => {
-  const { index, position } = hoveredPoint;
+  const { index } = hoveredPoint;
 
   return (
     <Tooltip
@@ -36,8 +45,8 @@ export const TooltipLayer: React.FC<TooltipLayerProps> = ({
       graphHeight={graphHeight}
       graphMargin={margin}
       position={{
-        x: xSelector.getScaledVal(data[index]),
-        y: position.y,
+        x,
+        y,
       }}
       show={hovering}
     >

--- a/packages/graph/src/themes/index.tsx
+++ b/packages/graph/src/themes/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { schemeCategory10, interpolateBlues, schemeBlues } from 'd3-scale-chromatic';
+import { schemeCategory10, interpolateCool, schemeBlues } from 'd3-scale-chromatic';
 import deepmerge from 'deepmerge';
 
 import { Theme } from '../common/types';
@@ -16,7 +16,7 @@ export const themes = {
       category: schemeCategory10,
       sequential: {
         scheme: schemeBlues,
-        interpolator: interpolateBlues,
+        interpolator: interpolateCool,
       },
     },
     xAxis: {

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -54,9 +54,15 @@ export function getAxisScale(
       scale = scaleBand().domain(domain).range(range);
       if (scaleConfig) {
         const { padding, paddingInner, paddingOuter } = scaleConfig;
-        if (padding) scale.padding(padding);
-        if (paddingInner) scale.paddingInner(paddingInner);
-        if (paddingOuter) scale.paddingOuter(paddingOuter);
+        if (padding) {
+          scale.padding(padding);
+        }
+        if (paddingInner) {
+          scale.paddingInner(paddingInner);
+        }
+        if (paddingOuter) {
+          scale.paddingOuter(paddingOuter);
+        }
       }
       break;
     }

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -3,6 +3,7 @@ import {
   scaleLinear,
   scalePoint,
   scaleTime,
+  scaleBand,
 } from 'd3-scale';
 
 import { AxisScale, AxisEncoding } from '../common/types';
@@ -50,6 +51,11 @@ export function getAxisScale(
       getValue = (val: string) => new Date(val);
       domain = d3Extent(dataVals.map(time => getValue(time)));
       scale = scaleTime().domain(domain).range(range);
+      break;
+    }
+    case 'band': {
+      domain = dataVals;
+      scale = scaleBand().domain(domain).range(range);
       break;
     }
     case 'linear':

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -7,6 +7,7 @@ import {
 } from 'd3-scale';
 
 import { getValByScaleType } from './getValByScaleType';
+import { getFieldValuesFromData } from './getFieldValuesFromData';
 
 import { AxisScale, ScaleType, AxisEncoding } from '../common/types';
 import { DEFAULT_VALS } from '../common/config';
@@ -30,13 +31,7 @@ export function getAxisScale(
   const range: AxisScale['range'] = [min, max];
   const { field, type, scaleConfig } = encoding;
 
-  const dataVals: any[] = [];
-  data.forEach((row) => {
-    const val = row[field];
-    if (val !== undefined && val !== null) {
-      dataVals.push(val);
-    }
-  });
+  const dataVals = getFieldValuesFromData(data, field);
 
   let domain: AxisScale['domain'];
   let scale;

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -6,7 +6,10 @@ import {
   scaleBand,
 } from 'd3-scale';
 
-import { AxisScale, AxisEncoding } from '../common/types';
+import { getValByScaleType } from './getValByScaleType';
+
+import { AxisScale, ScaleType, AxisEncoding } from '../common/types';
+import { DEFAULT_VALS } from '../common/config';
 
 export interface GetAxisScaleArgs {
   data: object[];
@@ -37,8 +40,8 @@ export function getAxisScale(
 
   let domain: AxisScale['domain'];
   let scale;
-  const scaleType = encoding.scale || 'linear';
-  let getValue = (val: any) => val;
+  const scaleType: ScaleType = encoding.scale || DEFAULT_VALS.SCALE_TYPE;
+  const getValue = getValByScaleType(scaleType);
 
   switch (scaleType) {
     case 'point': {
@@ -47,8 +50,6 @@ export function getAxisScale(
       break;
     }
     case 'time': {
-      // TODO: think out a way to deal with the date type
-      getValue = (val: string) => new Date(val);
       domain = d3Extent(dataVals.map(time => getValue(time)));
       scale = scaleTime().domain(domain).range(range);
       break;
@@ -76,7 +77,6 @@ export function getAxisScale(
     field,
     range,
     domain,
-    getValue,
     scaleType,
     type,
     scale,

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -25,7 +25,7 @@ export function getAxisScale(
   encoding: AxisEncoding,
 ): AxisScale {
   const range: AxisScale['range'] = [min, max];
-  const { field, type } = encoding;
+  const { field, type, scaleConfig } = encoding;
 
   const dataVals: any[] = [];
   data.forEach((row) => {
@@ -56,6 +56,12 @@ export function getAxisScale(
     case 'band': {
       domain = dataVals;
       scale = scaleBand().domain(domain).range(range);
+      if (scaleConfig) {
+        const { padding, paddingInner, paddingOuter } = scaleConfig;
+        if (padding) scale.padding(padding);
+        if (paddingInner) scale.paddingInner(paddingInner);
+        if (paddingOuter) scale.paddingOuter(paddingOuter);
+      }
       break;
     }
     case 'linear':

--- a/packages/graph/src/utils/getAxisScale.ts
+++ b/packages/graph/src/utils/getAxisScale.ts
@@ -6,11 +6,11 @@ import {
   scaleBand,
 } from 'd3-scale';
 
-import { getValByScaleType } from './getValByScaleType';
-import { getFieldValuesFromData } from './getFieldValuesFromData';
-
 import { AxisScale, ScaleType, AxisEncoding } from '../common/types';
 import { DEFAULT_VALS } from '../common/config';
+
+import { getValByScaleType } from './getValByScaleType';
+import { getFieldValuesFromData } from './getFieldValuesFromData';
 
 export interface GetAxisScaleArgs {
   data: object[];

--- a/packages/graph/src/utils/getColorScale.ts
+++ b/packages/graph/src/utils/getColorScale.ts
@@ -1,5 +1,5 @@
 import map from 'lodash/map';
-import sortedUniq from 'lodash/sortedUniq'
+import sortedUniq from 'lodash/sortedUniq';
 import { extent as d3Extent } from 'd3-array';
 import { scaleOrdinal, scaleSequential } from 'd3-scale';
 

--- a/packages/graph/src/utils/getColorScale.ts
+++ b/packages/graph/src/utils/getColorScale.ts
@@ -94,13 +94,11 @@ export function getColorScale({
 }: ColorScaleArgs): ColorScale {
   const { type, field } = encoding;
   const { scale, scaleType, domain, range } = getColorScaleSetting({ colors, encoding, data });
-  const getValue = (val: any) => val;
   return {
     scale,
     domain,
     type,
     field,
-    getValue,
     range,
     scaleType,
   };

--- a/packages/graph/src/utils/getFieldValuesFromData.ts
+++ b/packages/graph/src/utils/getFieldValuesFromData.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns an array of data selected by the given field name of the data array.
+ * It will filter out null and undefined values automatically.
+ * @param data - an array of data with various fields
+ * @param fieldName - the field to be selected
+ */
+export function getFieldValuesFromData(
+  data: object[],
+  fieldName: string,
+) {
+  const dataVals: any[] = [];
+  data.forEach((row) => {
+    const val = row[fieldName];
+    if (val !== undefined && val !== null) {
+      dataVals.push(val);
+    }
+  });
+  return dataVals;
+}

--- a/packages/graph/src/utils/getRecordFieldSelector.ts
+++ b/packages/graph/src/utils/getRecordFieldSelector.ts
@@ -1,5 +1,7 @@
 import { Scale } from '../common/types';
 
+import { getValByScaleType } from './getValByScaleType';
+
 /**
  * Returns the data value selectors for a data record
  * using the computed axis configurations including the d3Scale function of the axis
@@ -9,7 +11,8 @@ import { Scale } from '../common/types';
 export function getRecordFieldSelector(
   axis: Pick<Scale, Extract<keyof Scale, 'field' | 'scale' | 'getValue' | 'scaleType'>>,
 ) {
-  const { field, scale, getValue, scaleType } = axis;
+  const { field, scale, scaleType } = axis;
+  const getValue = getValByScaleType(scaleType);
 
   /** Given a record of data, it returns the orginal value of the specified field */
   const getOriginalVal = (record: object) => getValue(record[field]);

--- a/packages/graph/src/utils/getValByScaleType.ts
+++ b/packages/graph/src/utils/getValByScaleType.ts
@@ -1,0 +1,20 @@
+import { ScaleType } from '../common/types';
+import { DEFAULT_VALS } from '../common/config';
+
+/**
+ * Returns the orignal value of the data
+ * based on the scale type.
+ * It currently formats the date string as Date object.
+ */
+export function getValByScaleType(
+  scaleType: ScaleType = DEFAULT_VALS.SCALE_TYPE
+) {
+  let getValue = (val: any) => val;
+
+  if (scaleType === 'time') {
+    // TODO: think out a way to deal with the date type
+    getValue = (val: string) => new Date(val);
+  }
+
+  return getValue;
+}


### PR DESCRIPTION
# Purpose

Add vertical bar charts and stacked vertical bar charts to test if `useCartesianEncodings` can be shared among different charts.

# Changes

### Major Changes

#### Add vertical bar charts
![Screen Shot 2019-03-12 at 7 02 58 PM](https://user-images.githubusercontent.com/1139698/54195402-875bda00-44f9-11e9-9a39-278e2658b019.png)

#### Add vertical stacked bar charts
![Screen Shot 2019-03-12 at 7 03 09 PM](https://user-images.githubusercontent.com/1139698/54195405-89be3400-44f9-11e9-87d0-e6a76d25cf0b.png)

The stacked bar chart is created through `useCartesianEncodings` with some calculations of bar positions in `<BarChart>` instead of using the `stack()` of [d3-shape](https://github.com/d3/d3-shape#_stack) used in many charts since the data grouping by colors function is already well-written by @chenesan.

Thus, by making some changes to `useCartesianEncodings` we can get the scales for stacked bar charts.

### Other Changes

#### Allow the axes appear in the foreground
Making the axes appear in the back of the lines in line charts while making them appear in the front of the bars in bar charts seems to be more aesthetically pleasing, so the prop `axisInBackground` is added to `<SvgWithAxisFrame>`.

#### Add `getValByScaleType()`
Add `getValByScaleType()` so that format the value of data based on the provided scale without using the `getOriginalVal()` of `useCartesianEncodings`.

This change is made for the re-calculation of the domain of the scales of which the types are `band`-`linear`; we need to get computed data group before we update the domain of the linear scale, whose domain should be `the min value of the first data group` ~ `max accumulated value of a bar`.

# Screenshots

Stacked bar chart with the tooltip:

![screencast 2019-03-12 18-52-35](https://user-images.githubusercontent.com/1139698/54195230-174d5400-44f9-11e9-9849-093d082be4f0.gif)

# TODOs

- [ ] Support horizontal bar charts
- [ ] Support histograms
- [ ] Update the sample data to make the examples more intelligible
- [x] Support stacked bar chart that [does not start with zero value](https://c3js.org/samples/chart_bar_stacked.html)
- [ ] Display a horizontal line at zero if there are negative y values
- [ ] Make tooltip display all the values of the same column