### PR TITLE
Revert private field in root package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes simple components such as `<Foo>` and `<ResponsiveLayer>` as an experiment to see if the project settings go well. (#1)
 
 # Changed
+- Reset `private: true` in root package.json. (#24)
 - Remove author field in package.json. (#23)
 - Replace `lodash-es` with `lodash`.(#17)
 - Remove `selectors` from `AxisScale` and `ColorScale`. (#16)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/*"
   ],
   "license": "Apache-2.0",
+  "private": true,
   "scripts": {
     "start": "docz dev",
     "build:doc": "docz build",


### PR DESCRIPTION
# Purpose

Reset `private: true` on `package.json`, which is accidentally merged into develop in #21 and will cause `yarn install` failed.

# Change

- Reset `private: true` in root package.json.

# Risk

None.

# Todos

None.