### PR TITLE
Chore/auto release

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,6 +1,6 @@
 workflow "Push workflow" {
   on = "push"
-  resolves = ["type-check"]
+  resolves = ["release"]
 }
 
 action "install" {
@@ -12,4 +12,21 @@ action "type-check" {
   uses = "borales/actions-yarn@master"
   needs = ["install"]
   args = "type-check"
+}
+
+action "Filters for GitHub Actions" {
+  uses = "actions/bin/filter@master"
+  args = "branch master"
+}
+
+action "Filters for master" {
+  uses = "actions/bin/filter@master"
+  needs = ["type-check"]
+  args = "branch master"
+}
+
+action "release" {
+  uses = "borales/actions-yarn@master"
+  needs = ["Filters for master"]
+  args = "release"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add auto release script and github action. (#28)
+
 ## [0.0.2]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "jest ./packages --config=config/jest.config.js --coverage",
     "test:watch": "jest ./packages --watch --config=config/jest.config.js",
     "bumpversion": "lerna version --no-push --no-git-tag-version",
-    "release": "lerna publish --yes --repo-version $PACKAGE_VERSION --no-push --no-git-tag-version",
+    "release": "lerna publish from-package --yes --no-push --no-git-tag-version",
     "release:beta": "lerna publish --no-push --no-git-tag-version --preid=beta --npm-tag=prerelease",
     "release:canary": "lerna publish -c --yes --exact"
   },


### PR DESCRIPTION
# Purpose

Fix release script and add auto release when push on master.

# Change

- Fix `yarn release` by getting version from package.json
- Add github action to run release script on pushing to master.

# Risks

Not sure if the `push` event will be triggered when pr is merged.
(Updated: make sure it will trigger push event when merging like https://launch-editor.github.com/actions?runID=MDEwOkNoZWNrU3VpdGU4MTM1NjM2NA%3D%3D&nwo=iCHEF%2Ftranscharts)

# Todos

- [x] Make sure this is only trigger when merge PR into master.
