### PR TITLE
Bugfix/fix chart dependency

### DIFF
--- a/packages/chart/package.json
+++ b/packages/chart/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/iCHEF/transcharts/issues"
   },
   "dependencies": {
-    "@ichef/transcharts-graph": "^0.0.1",
+    "@ichef/transcharts-graph": "^0.0.2",
     "@vx/axis": "^0.0.183",
     "@vx/shape": "^0.0.183"
   },


### PR DESCRIPTION
# Purpose

Fix `yarn install` downloading `@ichef/transcharts-graph` on npm registry due to version difference.
It looks like `yarn bumpversion` doesn't handle version in `dependencies` of `package.json` properly when it's published first time (0627ad2 doesn't update version in package.json). I'm sure that `yarn bumpversion` will also update version in `dependencies` now.

# Changes

- Fix dependency of `chart`.

# Screenshots

None.

# Risks

None.

# TODOs

None.
