### PR TITLE
Turn off type checker on docz if it is in production

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,20 +1,20 @@
 import * as path from 'path';
 import ForkTSCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 
-const modifyBundlerConfig = config => {
+const modifyBundlerConfig = (config, dev) => {
   config.resolve.alias = Object.assign({}, config.resolve.alias, {
     '@ichef/transcharts-graph': path.resolve(__dirname, 'packages/graph/src'),
     '@ichef/transcharts-chart': path.resolve(__dirname, 'packages/chart/src'),
     '@ichef/transcharts-animation': path.resolve(__dirname, 'packages/animation/src'),
   });
-  const customPlugins = [
+  const customPlugins = dev ? [
     new ForkTSCheckerWebpackPlugin({
       tsconfig: './config/tsconfig.docz.json',
       async: false,
       watch: ['./packages/**/*.{ts,tsx}'],
       tslint: true,
     }),
-  ];
+  ] : [];
   config.plugins.push(...customPlugins)
   return config;
 };


### PR DESCRIPTION
# Purpose

Sometimes the type check github action fails during building doc when executing `yarn` (which trigger `yarn prepublish`) (like https://github.com/iCHEF/transcharts/pull/29/checks?check_run_id=79929395) and this PR try to turn off type checking when it's in production build so the type-check github action will always work.

# Changes

- Turn off `ForkTSCheckerWebpackPlugin` when `dev` is false.

# Risks

None.

# TODOs

None.
