### PR TITLE
Make the default tslint settings for docz as warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Makes simple components such as `<Foo>` and `<ResponsiveLayer>` as an experiment to see if the project settings go well. (#1)
 
 # Changed
+- Change the default tslint `defaultSeverity` settings for docz from `error` to `warning`. (#32)
 - Reset `private: true` in root package.json. (#24)
 - Remove author field in package.json. (#23)
 - Replace `lodash-es` with `lodash`.(#17)

--- a/config/tslint.docz.json
+++ b/config/tslint.docz.json
@@ -1,0 +1,6 @@
+{
+  "defaultSeverity": "warning",
+  "extends": [
+    "../tslint.json"
+  ]
+}

--- a/doczrc.js
+++ b/doczrc.js
@@ -12,7 +12,7 @@ const modifyBundlerConfig = config => {
       tsconfig: './config/tsconfig.docz.json',
       async: false,
       watch: ['./packages/**/*.{ts,tsx}'],
-      tslint: true,
+      tslint: './config/tslint.docz.json'
     }),
   ];
   config.plugins.push(...customPlugins)


### PR DESCRIPTION
# Purpose

Change the default tslint `defaultSeverity` settings for docz from `error` to `warning` to avoid problems such as we can not see results of `console.log`; it is also the [recommended](https://github.com/Realytics/fork-ts-checker-webpack-plugin#tslint) by the documentation of `https://github.com/Realytics/fork-ts-checker-webpack-plugin#tslint`.

# Changes

- Change the default tslint `defaultSeverity` settings for docz from `error` to `warning`.
