### PR TITLE
[Feature] Support multiple value display when there are multiple points on the same x positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add auto release script and github action. (#28)
+# Changed
+- Support multiple value display when there are multiple points on the same x positions. (#33)
+- Rename the collisionComponents as hoverDetectionComponents to made the name more intelligible. (#33)
 
 ## [0.0.2]
 

--- a/docs/sampleData/lineData.js
+++ b/docs/sampleData/lineData.js
@@ -1,7 +1,7 @@
 const lineData = [
   { x: 0, y: 9, date: '2019/01/21 00:00:00', weekday: 'Mon' },
   { x: 1, y: 5, date: '2019/01/22 00:00:00', weekday: 'Tue' },
-  { x: 2, y: 5, date: '2019/01/23 00:00:00', weekday: 'Wed' },
+  { x: 2.5, y: 5, date: '2019/01/23 00:00:00', weekday: 'Wed' },
   { x: 3, y: 3, date: '2019/01/24 00:00:00', weekday: 'Thu'},
   { x: 4, y: 1, date: '2019/01/25 00:00:00', weekday: 'Fri' },
 ];

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -108,7 +108,8 @@ export const BarChart = ({
   const bandWidth = bandScale.bandwidth();
 
   /**
-   * Returns the size and position of the collision rectangle or hovering highlight rectangle
+   * Returns the size and position of the hovering detection rectangle
+   * or hovering highlight rectangle
    */
   const getHoveringRectPos = useCallback(
     (idx: number) => {
@@ -128,6 +129,29 @@ export const BarChart = ({
       };
     },
     [bandWidth, paddingInner],
+  );
+
+  const hoverDetectionComponents = useMemo(
+    () => (
+      axisProjectedValues.map(
+        (row, idx) => {
+          return (
+            <rect
+              // #TODO: use unique keys rather than array index
+              key={`colli-${idx}`}
+              x={row.xPos}
+              y={0}
+              height={graphHeight}
+              width={bandWidth}
+              fill={(idx % 2 === 0) ? '#abfa11' : '#abcdef'}
+              opacity={0.3}
+              {...{ ...getHoveringRectPos(idx) }}
+            />
+          );
+        }
+      )
+    ),
+    [axisProjectedValues, graphHeight, bandWidth, getHoveringRectPos]
   );
 
   const graphGroup = useMemo(
@@ -224,23 +248,7 @@ export const BarChart = ({
       <HoverLayer
         setHoveredPosAndIndex={setHoveredPosAndIndex}
         clearHovering={clearHovering}
-        collisionComponents={axisProjectedValues.map(
-          (row, idx) => {
-            return (
-              <rect
-                // #TODO: use unique keys rather than array index
-                key={`colli-${idx}`}
-                x={row.xPos}
-                y={0}
-                height={graphHeight}
-                width={bandWidth}
-                fill={(idx % 2 === 0) ? '#abfa11' : '#abcdef'}
-                opacity={0.3}
-                {...{ ...getHoveringRectPos(idx) }}
-              />
-            );
-          }
-        )}
+        hoverDetectionComponents={hoverDetectionComponents}
       />
     </SvgWithAxisFrame>
   );

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -99,6 +99,7 @@ export const BarChart = ({
     dataGroups,
     scalesConfig,
     rowValSelectors,
+    axisProjectedValues,
   } = useCartesianEncodings(graphDimension, theme, data, xEncoding, yEncoding, color);
   const { clearHovering, hovering, hoveredPoint, setHoveredPosAndIndex } = useHoverState();
 
@@ -196,14 +197,11 @@ export const BarChart = ({
           <TooltipLayer
             hovering={hovering}
             hoveredPoint={hoveredPoint}
-            data={data}
+            axisProjectedValues={axisProjectedValues}
             graphWidth={graphWidth}
             graphHeight={graphHeight}
             margin={margin}
-            xSelector={rowValSelectors.x}
-            ySelector={rowValSelectors.y}
             x={rowValSelectors.x.getScaledVal(data[hoveredPoint.index]) + bandWidth / 2}
-            getColor={rowValSelectors.color.getString}
           />
           {/* Draw the legned */}
           <LegendGroup
@@ -232,7 +230,8 @@ export const BarChart = ({
               <rect
                 // #TODO: use unique keys rather than array index
                 key={`colli-${idx}`}
-                opacity={0}
+                fill="#abfa11"
+                opacity={0.3}
                 {...{ ...getHoveringRectPos(idx) }}
               />
             );

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -115,7 +115,7 @@ export const BarChart = ({
       const paddingVal = bandWidth * paddingInner;
       const xPos = idx === 0
         ? 0
-        : rowValSelectors.x.getScaledVal(data[idx]) - paddingVal / 2;
+        : axisProjectedValues[idx].xPos - paddingVal / 2;
       const width = idx === 0 || idx === data.length - 1
             ? bandWidth + paddingVal / 2
             : bandWidth + paddingVal;
@@ -201,7 +201,7 @@ export const BarChart = ({
             graphWidth={graphWidth}
             graphHeight={graphHeight}
             margin={margin}
-            x={rowValSelectors.x.getScaledVal(data[hoveredPoint.index]) + bandWidth / 2}
+            xOffset={bandWidth / 2}
           />
           {/* Draw the legned */}
           <LegendGroup
@@ -224,13 +224,17 @@ export const BarChart = ({
       <HoverLayer
         setHoveredPosAndIndex={setHoveredPosAndIndex}
         clearHovering={clearHovering}
-        collisionComponents={data.map(
-          (_, idx) => {
+        collisionComponents={axisProjectedValues.map(
+          (row, idx) => {
             return (
               <rect
                 // #TODO: use unique keys rather than array index
                 key={`colli-${idx}`}
-                fill="#abfa11"
+                x={row.xPos}
+                y={0}
+                height={graphHeight}
+                width={bandWidth}
+                fill={(idx % 2 === 0) ? '#abfa11' : '#abcdef'}
                 opacity={0.3}
                 {...{ ...getHoveringRectPos(idx) }}
               />

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -143,8 +143,7 @@ export const BarChart = ({
               y={0}
               height={graphHeight}
               width={bandWidth}
-              fill={(idx % 2 === 0) ? '#abfa11' : '#abcdef'}
-              opacity={0.3}
+              opacity={0}
               {...{ ...getHoveringRectPos(idx) }}
             />
           );

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext, useMemo, useCallback } from 'react';
+import React, { useContext, useMemo, useCallback } from 'react';
 import { ScaleBand, ScaleLinear } from 'd3-scale';
 import {
   // from HoverLayer
@@ -24,13 +24,13 @@ import { SvgWithAxisFrame } from '../frames/SvgWithAxisFrame';
 import { DEFAULT_VALS } from '../common/config';
 
 /** A line and a dot for the point being hovered */
-const HoveringIndicator: FunctionComponent<{
+const HoveringIndicator = ({ hovering, x, y, width, height }: {
   hovering: boolean,
   x: number,
   y: number,
   width: number,
   height: number,
-}> = ({ hovering, x, y, width, height }) => {
+}) => {
   if (!hovering) {
     return null;
   }

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -167,9 +167,41 @@ export const useCartesianEncodings = (
     [colorScale, defaultColor],
   );
 
+  const axisProjectedValues = useMemo(
+    () => {
+      const projections = {};
+      dataGroups.forEach((group, groupIdx) => {
+        group.forEach((row) => {
+          // TODO: use rowValSelectors to get values
+          const xVal = xSelector.getOriginalVal(row);
+          const yVal = ySelector.getOriginalVal(row);
+          if (!projections[xVal]) {
+            projections[xVal] = [];
+          }
+          projections[xVal].push({ [groupIdx]: yVal });
+        });
+      });
+
+      return projections;
+    },
+    [dataGroups, xSelector, ySelector],
+   );
+
   return {
     /** Array of data grouped by fields of colors  */
     dataGroups,
+
+    /**
+     * The y-values in the `dataGroups` grouped by x-values.
+     * - Its return structure:
+     *   { "value on the axis": [ { "data group index": "value" }, ... ], ... }
+     * @example {
+     *  0: [{ 0: 100 }, { 1: 200 }],
+     *  2.5: [{ 0: 400 }, { 1: 800 }],
+     *  3: [{ 0: 50 }]
+     * }
+     */
+    axisProjectedValues,
 
     /** d3 scale functions and other related configurations computed for various encodings */
     scalesConfig: {

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -172,12 +172,14 @@ export const useCartesianEncodings = (
       // project by original values on the axis
       // expected results: { "value on the axis": [ { "data group index": "value" }, ... ], ... }
       const projections = {};
+      const xValues = {};
       dataGroups.forEach((group, groupIdx) => {
         group.forEach((row) => {
           const xVal = xSelector.getOriginalVal(row);
           const yVal = ySelector.getOriginalVal(row);
           if (!projections[xVal]) {
             projections[xVal] = [];
+            xValues[xVal] = xVal;
           }
           projections[xVal].push({ [groupIdx]: yVal });
         });
@@ -185,8 +187,10 @@ export const useCartesianEncodings = (
 
       // convert the position along the axis, and sort by the converted values
       const columns = Object.keys(projections).reduce(
-        (accum, xVal: any) => {
-          const groupedY = projections[xVal];
+        (accum, xKey: any) => {
+          const groupedY = projections[xKey];
+          // ensure that we always get the correct type, not a string instead
+          const xVal = xValues[xKey];
           const xPos: number = xAxis.scale(xVal) || 0;
           const column = {
             xPos,
@@ -203,6 +207,8 @@ export const useCartesianEncodings = (
     },
     [dataGroups, xSelector, ySelector],
    );
+
+    console.log(axisProjectedValues)
 
   return {
     /** Array of data grouped by fields of colors  */

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -15,6 +15,8 @@ import {
   GraphDimension,
   // from themes
   Theme,
+  // from TooltipLayer
+  AxisProjectedValue,
 } from '@ichef/transcharts-graph';
 
 /**
@@ -167,21 +169,26 @@ export const useCartesianEncodings = (
     [colorScale, defaultColor],
   );
 
-  const axisProjectedValues = useMemo(
+  const axisProjectedValues: AxisProjectedValue[] = useMemo(
     () => {
       // project by original values on the axis
-      // expected results: { "value on the axis": [ { "data group index": "value" }, ... ], ... }
       const projections = {};
       const xValues = {};
       dataGroups.forEach((group, groupIdx) => {
         group.forEach((row) => {
           const xVal = xSelector.getOriginalVal(row);
           const yVal = ySelector.getOriginalVal(row);
+          const yPos = ySelector.getScaledVal(row);
           if (!projections[xVal]) {
             projections[xVal] = [];
             xValues[xVal] = xVal;
           }
-          projections[xVal].push({ [groupIdx]: yVal });
+          projections[xVal].push({
+            groupIdx,
+            yVal,
+            yPos,
+            color: getColorString(row),
+          });
         });
       });
 
@@ -206,9 +213,7 @@ export const useCartesianEncodings = (
       return columns.sort((a, b) => (a.xPos - b.xPos));
     },
     [dataGroups, xSelector, ySelector],
-   );
-
-    console.log(axisProjectedValues)
+  );
 
   return {
     /** Array of data grouped by fields of colors  */
@@ -221,12 +226,12 @@ export const useCartesianEncodings = (
      * [{
      *  "xPos": 0,
      *  "xVal": "0",
-     *  "groupedY": [{"0": 9}],
+     *  "groupedY": [{"groupIdx": 0, "yVal": 9, "yPos": 18, "color": "#deebf7"}],
      *  },
      * {
      *  "xPos": 109.12812500000001,
      *  "xVal": "2",
-     *  "groupedY": [{"0": 3}, {"1": 5}],
+     *  "groupedY": [{"groupIdx": 0, "yVal": 3, "yPos": 6, "color": "#deebf7"}, ...],
      * }]
      */
     axisProjectedValues,

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -19,6 +19,8 @@ import {
   AxisProjectedValue,
 } from '@ichef/transcharts-graph';
 
+import { getAxisProjectedValues } from '../utils/getAxisProjectedValues';
+
 /**
  * Return [min, max] of a column selected from the grouped data
  */
@@ -171,48 +173,9 @@ export const useCartesianEncodings = (
 
   const axisProjectedValues: AxisProjectedValue[] = useMemo(
     () => {
-      // project by original values on the axis
-      const projections = {};
-      const xPositions = {};
-      dataGroups.forEach((group, groupIdx) => {
-        group.forEach((row) => {
-          const xStrVal = xSelector.getFormattedStringVal(row);
-          const yStrVal = ySelector.getFormattedStringVal(row);
-          const xPos = xSelector.getScaledVal(row);
-          const yPos = ySelector.getScaledVal(row);
-          if (!projections[xStrVal]) {
-            projections[xStrVal] = [];
-            xPositions[xStrVal] = xPos;
-          }
-          projections[xStrVal].push({
-            groupIdx,
-            yStrVal,
-            yPos,
-            color: getColorString(row),
-          });
-        });
-      });
-
-      // convert the position along the axis, and sort by the converted values
-      const columns = Object.keys(projections).reduce(
-        (accum, xStrVal: any) => {
-          const groupedY = projections[xStrVal];
-          // ensure that we always get the correct type, not a string instead
-          const xPos: number = xPositions[xStrVal] || 0;
-          const column = {
-            xPos,
-            xStrVal,
-            groupedY,
-          };
-
-          return [...accum, column];
-        },
-        []
-      );
-
-      return columns.sort((a, b) => (a.xPos - b.xPos));
+      return getAxisProjectedValues(dataGroups, xSelector, ySelector, getColorString);
     },
-    [dataGroups, xSelector, ySelector],
+    [dataGroups, xSelector, ySelector, getColorString],
   );
 
   return {

--- a/packages/chart/src/hooks/useCartesianEncodings.ts
+++ b/packages/chart/src/hooks/useCartesianEncodings.ts
@@ -173,19 +173,20 @@ export const useCartesianEncodings = (
     () => {
       // project by original values on the axis
       const projections = {};
-      const xValues = {};
+      const xPositions = {};
       dataGroups.forEach((group, groupIdx) => {
         group.forEach((row) => {
-          const xVal = xSelector.getOriginalVal(row);
-          const yVal = ySelector.getOriginalVal(row);
+          const xStrVal = xSelector.getFormattedStringVal(row);
+          const yStrVal = ySelector.getFormattedStringVal(row);
+          const xPos = xSelector.getScaledVal(row);
           const yPos = ySelector.getScaledVal(row);
-          if (!projections[xVal]) {
-            projections[xVal] = [];
-            xValues[xVal] = xVal;
+          if (!projections[xStrVal]) {
+            projections[xStrVal] = [];
+            xPositions[xStrVal] = xPos;
           }
-          projections[xVal].push({
+          projections[xStrVal].push({
             groupIdx,
-            yVal,
+            yStrVal,
             yPos,
             color: getColorString(row),
           });
@@ -194,14 +195,13 @@ export const useCartesianEncodings = (
 
       // convert the position along the axis, and sort by the converted values
       const columns = Object.keys(projections).reduce(
-        (accum, xKey: any) => {
-          const groupedY = projections[xKey];
+        (accum, xStrVal: any) => {
+          const groupedY = projections[xStrVal];
           // ensure that we always get the correct type, not a string instead
-          const xVal = xValues[xKey];
-          const xPos: number = xAxis.scale(xVal) || 0;
+          const xPos: number = xPositions[xStrVal] || 0;
           const column = {
             xPos,
-            xVal,
+            xStrVal,
             groupedY,
           };
 
@@ -225,13 +225,13 @@ export const useCartesianEncodings = (
      * @example
      * [{
      *  "xPos": 0,
-     *  "xVal": "0",
-     *  "groupedY": [{"groupIdx": 0, "yVal": 9, "yPos": 18, "color": "#deebf7"}],
+     *  "xStrVal": "0",
+     *  "groupedY": [{"groupIdx": 0, "yStrVal": 9, "yPos": 18, "color": "#deebf7"}],
      *  },
      * {
      *  "xPos": 109.12812500000001,
-     *  "xVal": "2",
-     *  "groupedY": [{"groupIdx": 0, "yVal": 3, "yPos": 6, "color": "#deebf7"}, ...],
+     *  "xStrVal": "2",
+     *  "groupedY": [{"groupIdx": 0, "yStrVal": 3, "yPos": 6, "color": "#deebf7"}, ...],
      * }]
      */
     axisProjectedValues,

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -29,7 +29,7 @@ import { DEFAULT_VALS } from '../common/config';
  * Return the position of the hovering detection rect.
  * If the given index exceeds its bound, it will return its closest value.
  */
-function getXPosByIndex(arr: any[], idx: number) {
+function getXPosByIndex(arr: AxisProjectedValue[], idx: number) {
   let arrIdx = idx < 0 ? 0 : idx;
   if (idx >= arr.length) {
     arrIdx = arr.length - 1;

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -61,7 +61,7 @@ const HoveringIndicator: FunctionComponent<{
 
   const circles = projectedPoints.groupedY.map(pointY => (
     <circle
-      key={`${projectedPoints.xVal}-${pointY.yVal}`}
+      key={`c-${pointY.yStrVal}`}
       cx={projectedPoints.xPos}
       cy={pointY.yPos}
       r={4.5}
@@ -161,9 +161,6 @@ export const LineChart = ({
       );
     },
   );
-
-  // TODO: use step() of pointScale to calculate the width of collision band
-  // scalesConfig.x.scale.step().length
 
   return (
     <SvgWithAxisFrame

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -189,8 +189,7 @@ export const LineChart = ({
               y={0}
               width={rectWidth}
               height={graphHeight}
-              fill={(idx % 2 === 0) ? '#abfa11' : '#abcdef'}
-              opacity={0.3}
+              opacity={0}
             />
           );
         }

--- a/packages/chart/src/line/LineChart.tsx
+++ b/packages/chart/src/line/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent, useContext, useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { LinePath } from '@vx/shape';
 import {
   // from HoverLayer
@@ -54,11 +54,11 @@ export interface LineChartProps {
 }
 
 /** A line and a dot for the point being hovered */
-const HoveringIndicator: FunctionComponent<{
+const HoveringIndicator = ({ hovering, projectedPoints, height }: {
   hovering: boolean,
   projectedPoints: AxisProjectedValue,
   height: number,
-}> = ({ hovering, projectedPoints, height }) => {
+}) => {
   if (!hovering) {
     return null;
   }
@@ -87,12 +87,12 @@ const HoveringIndicator: FunctionComponent<{
   );
 };
 
-const DataLine: FunctionComponent<{
+const DataLine = ({ color, xSelector, ySelector, rows }: {
   color: string,
   xSelector: FieldSelector,
   ySelector: FieldSelector,
   rows: object[],
-}> = ({ color, xSelector, ySelector, rows }) => {
+}) => {
   const lineDots = rows.map((dataRow, index) => (
     <circle
       key={`c-${index}`}

--- a/packages/chart/src/utils/getAxisProjectedValues.ts
+++ b/packages/chart/src/utils/getAxisProjectedValues.ts
@@ -1,0 +1,74 @@
+import {
+  // from common types
+  FieldSelector,
+} from '@ichef/transcharts-graph';
+
+/**
+ * Return the y-values in the `dataGroups` grouped by projected x values.
+ * -  Structure of groupedY: "groupedY":[ { "index of dataGroup": "value" }, ... ]
+ * @example
+ * [{
+ *  "xPos": 0,
+ *  "xStrVal": "0",
+ *  "groupedY": [{"groupIdx": 0, "yStrVal": 9, "yPos": 18, "color": "#deebf7"}],
+ *  },
+ * {
+ *  "xPos": 109.12812500000001,
+ *  "xStrVal": "2",
+ *  "groupedY": [{"groupIdx": 0, "yStrVal": 3, "yPos": 6, "color": "#deebf7"}, ...],
+ * }]
+ */
+export function getAxisProjectedValues(
+  /** Data grouped in `useCartesianEncodings()`  */
+  dataGroups: object[][],
+
+  /** Functions to get value on the x-axis */
+  xSelector: FieldSelector,
+
+  /** Functions to get value on the y-axis */
+  ySelector: FieldSelector,
+
+  /** Functions to get the formatted color string */
+  getColorString: (record: any) => string,
+) {
+  // project by original values on the axis
+  const projections = {};
+  const xPositions = {};
+  dataGroups.forEach((group, groupIdx) => {
+    group.forEach((row) => {
+      const xStrVal = xSelector.getFormattedStringVal(row);
+      const yStrVal = ySelector.getFormattedStringVal(row);
+      const xPos = xSelector.getScaledVal(row);
+      const yPos = ySelector.getScaledVal(row);
+      if (!projections[xStrVal]) {
+        projections[xStrVal] = [];
+        xPositions[xStrVal] = xPos;
+      }
+      projections[xStrVal].push({
+        groupIdx,
+        yStrVal,
+        yPos,
+        color: getColorString(row),
+      });
+    });
+  });
+
+  // convert the position along the axis, and sort by the converted values
+  const columns = Object.keys(projections).reduce(
+    (accum, xStrVal: any) => {
+      const groupedY = projections[xStrVal];
+      // ensure that we always get the correct type, not a string instead
+      const xPos: number = xPositions[xStrVal] || 0;
+      const column = {
+        xPos,
+        xStrVal,
+        groupedY,
+      };
+
+      return [...accum, column];
+    },
+    []
+  );
+
+  return columns.sort((a, b) => (a.xPos - b.xPos));
+}

--- a/packages/graph/src/layers/HoverLayer.tsx
+++ b/packages/graph/src/layers/HoverLayer.tsx
@@ -15,7 +15,7 @@ export type HoverLayerProps = {
    * Hidden components to detect the mouse or touch interactions.
    * **Note:** The order of the components should correspond to the order of the data.
    */
-  collisionComponents: JSX.Element[];
+  hoverDetectionComponents: JSX.Element[];
 } & typeof defaultProps;
 
 const defaultProps = {
@@ -30,7 +30,7 @@ export const HoverLayer = ({
   setHoveredPosAndIndex,
   handleHover,
   clearHovering,
-  collisionComponents,
+  hoverDetectionComponents,
   throttleTime,
 }: HoverLayerProps) => {
   /** use requestAnimationFrame to schedule updates of hovered position and data index */
@@ -78,7 +78,7 @@ export const HoverLayer = ({
     [updatePosition, clearHovering],
   );
 
-  const detectionAreas = collisionComponents.map((area: JSX.Element, dataIndex: number) => {
+  const detectionAreas = hoverDetectionComponents.map((area: JSX.Element, dataIndex: number) => {
     const handleCurrentTooltip = handleTooltip(dataIndex);
     return React.cloneElement(area, {
       onTouchStart: handleCurrentTooltip,
@@ -88,7 +88,7 @@ export const HoverLayer = ({
     });
   });
 
-  // Render areas to detect collisions of mouse pointers or touches with data points
+  // Render areas to detect hovering interaction with mouse pointers or touches with data points
   return (
     <>
       {detectionAreas}

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -1,43 +1,65 @@
 import * as React from 'react';
 
-import { Margin, FieldSelector, HoveringState, HoveredPointState } from '../common/types';
+import { Margin, HoveringState, HoveredPointState } from '../common/types';
 import { Tooltip } from '../tooltip/Tooltip';
 import { TooltipItem } from '../tooltip/TooltipItem';
+export interface GroupedY {
+  /** Index of `dataGroups` */
+  groupIdx: number;
+
+  /** Original value on Y */
+  yVal: number;
+
+  /** Projected position of Y */
+  yPos: number;
+
+  /** Color string of the point */
+  color: string;
+}
+export interface AxisProjectedValue {
+  /** Projected position of X */
+  xPos: number;
+
+  /** Original value on X */
+  xVal: number;
+
+  /** Corresponding data in `dataGroups` */
+  groupedY: GroupedY[];
+}
 
 export interface TooltipLayerProps {
   hovering: HoveringState;
   hoveredPoint: HoveredPointState;
-  data: object[];
+  axisProjectedValues: AxisProjectedValue[];
   graphWidth: number;
   graphHeight: number;
   margin: Margin;
-  xSelector: FieldSelector;
-  ySelector: FieldSelector;
 
   /** X position of the tooltip */
   x?: number;
 
   /** Y position of the tooltip */
   y?: number;
-
-  getColor: FieldSelector['getScaledVal'];
 }
 
 /** Generates the tooltip box */
 export const TooltipLayer = ({
   hovering,
   hoveredPoint,
-  data,
+  axisProjectedValues,
   graphWidth,
   graphHeight,
   margin,
-  xSelector,
-  ySelector,
-  x = xSelector.getScaledVal(data[hoveredPoint.index]),
+  x = axisProjectedValues[hoveredPoint.index].xPos,
   y = hoveredPoint.position.y,
-  getColor,
 }: TooltipLayerProps) => {
-  const { index } = hoveredPoint;
+  const projected = axisProjectedValues[hoveredPoint.index];
+  const tooltipItems = projected.groupedY.map(pointY => (
+    <TooltipItem
+      color={pointY.color}
+      text={`${pointY.yVal}`}
+    />
+  ));
 
   return (
     <Tooltip
@@ -50,11 +72,8 @@ export const TooltipLayer = ({
       }}
       show={hovering}
     >
-      <h3>{xSelector.getFormattedStringVal(data[index])}</h3>
-      <TooltipItem
-        color={getColor(data[index])}
-        text={ySelector.getFormattedStringVal(data[index])}
-      />
+      <h3>{projected.xVal}</h3>
+      {tooltipItems}
     </Tooltip>
   );
 };

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -8,7 +8,7 @@ export interface GroupedY {
   groupIdx: number;
 
   /** Original value on Y */
-  yVal: number;
+  yStrVal: number;
 
   /** Projected position of Y */
   yPos: number;
@@ -21,7 +21,7 @@ export interface AxisProjectedValue {
   xPos: number;
 
   /** Original value on X */
-  xVal: number;
+  xStrVal: number;
 
   /** Corresponding data in `dataGroups` */
   groupedY: GroupedY[];
@@ -56,8 +56,9 @@ export const TooltipLayer = ({
   const projected = axisProjectedValues[hoveredPoint.index];
   const tooltipItems = projected.groupedY.map(pointY => (
     <TooltipItem
+      key={`t-${pointY.yStrVal}`}
       color={pointY.color}
-      text={`${pointY.yVal}`}
+      text={`${pointY.yStrVal}`}
     />
   ));
 
@@ -72,7 +73,7 @@ export const TooltipLayer = ({
       }}
       show={hovering}
     >
-      <h3>{projected.xVal}</h3>
+      <h3>{`${projected.xStrVal}`}</h3>
       {tooltipItems}
     </Tooltip>
   );

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -40,6 +40,12 @@ export interface TooltipLayerProps {
 
   /** Y position of the tooltip */
   y?: number;
+
+  /** X offset for the position of the tooltip */
+  xOffset?: number;
+
+  /** Y offset for the of the tooltip */
+  yOffset?: number;
 }
 
 /** Generates the tooltip box */
@@ -52,6 +58,8 @@ export const TooltipLayer = ({
   margin,
   x = axisProjectedValues[hoveredPoint.index].xPos,
   y = hoveredPoint.position.y,
+  xOffset = 0,
+  yOffset = 0,
 }: TooltipLayerProps) => {
   const projected = axisProjectedValues[hoveredPoint.index];
   const tooltipItems = projected.groupedY.map(pointY => (
@@ -68,8 +76,8 @@ export const TooltipLayer = ({
       graphHeight={graphHeight}
       graphMargin={margin}
       position={{
-        x,
-        y,
+        x: x + xOffset,
+        y: y + yOffset,
       }}
       show={hovering}
     >

--- a/packages/graph/src/layers/TooltipLayer.tsx
+++ b/packages/graph/src/layers/TooltipLayer.tsx
@@ -44,7 +44,7 @@ export interface TooltipLayerProps {
   /** X offset for the position of the tooltip */
   xOffset?: number;
 
-  /** Y offset for the of the tooltip */
+  /** Y offset for the position of the tooltip */
   yOffset?: number;
 }
 

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -32,7 +32,7 @@ const TooltipWrapper = styled.div`
 
   h3 {
     color: #7c8a94;
-    margin: 0.25rem 0;
+    margin: 0.15rem 0 0.4rem 0.1rem;
     font-size: 1.1rem;
   }
 `;

--- a/packages/graph/src/tooltip/TooltipItem.tsx
+++ b/packages/graph/src/tooltip/TooltipItem.tsx
@@ -8,7 +8,7 @@ export interface TooltipItemProps {
 }
 
 const ItemWrapper = styled.div`
-  margin: 0.25rem 0;
+  margin: 0.1rem 0;
 
   &:before {
     content: '';
@@ -16,7 +16,7 @@ const ItemWrapper = styled.div`
     height: 0.35rem;
     background-color: ${({ color }) => color};
     float: left;
-    margin: 0.5rem 0.8rem 0 0.2rem;
+    margin: 0.5rem 0.8rem 0 0.1rem;
     border-radius: 50%;
   }
 `;


### PR DESCRIPTION
# Purpose

Our previous implementation of tooltip does not support [displaying multiple values](https://github.com/iCHEF/transcharts/issues/25) when there are multiple points on the same x positions. 

In addition, it uses **equally wide bands** to detect the hovering interactions which are ill-suited for the linear scale. For instance, for data with `domain=[0, 4]` and `ticks=4`, and there is a non-integer x value such as `2.5`, the hovering detection band cannot be situated at the right position.

To cope with the problems above, and to create more universal ways to generate hovering detection bands for various scales, we unify the way we create the bands by:

- Aggregate the data in the `dataGroup` by its corresponding x-value, then we can know how many bands we are going to create, and their x-positions.

- Calculate the hovering detection band size by taking the position of the previous band and the next band into account.


![Transchart 2019-03-20 18-48-59](https://user-images.githubusercontent.com/1139698/54679720-fdd48980-4b42-11e9-80a7-33d4980a2c02.jpg)

The aggregation of x positions of the bands is realized through `axisProjectedValues` in `useCartesianEncodings()` which also aggregates the values and positions of y. When a band is being hovered, it displays a tooltip with the values stored in the corresponding index of `axisProjectedValues`.

##### Its structure:

```json
 [{
  "xPos": 0,
   "xStrVal": "0",
   "groupedY": [{"groupIdx": 0, "yStrVal": 9, "yPos": 18, "color": "#deebf7"}],
   },
  {
   "xPos": 109.12812500000001,
   "xStrVal": "2",
   "groupedY": [{"groupIdx": 0, "yStrVal": 3, "yPos": 6, "color": "#deebf7"}, ...],
  }]
```

# Changes

- Support multiple value display when there are multiple points on the same x positions.
- Rename the `collisionComponents` as `hoverDetectionComponents` to made the name more intelligible.

# Screenshots

### Line Chart
![screencast 2019-03-20 18-52-35](https://user-images.githubusercontent.com/1139698/54679496-62dbaf80-4b42-11e9-8c83-697cb9e85e0a.gif)

### Bar Chart
![screencast 2019-03-20 18-54-08](https://user-images.githubusercontent.com/1139698/54679498-64a57300-4b42-11e9-82f3-0b8e6b515240.gif)



# TODOs

- [ ] Support tooltips on the vertical charts (we only have horizontal charts currently).