### PR TITLE
 Clean compiled files when developing & Prevent docz from throwing TypeError 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add auto release script and github action. (#28)
 # Changed
+- Clean compiled files before the docz server started. (#34)
+- Prevent docz from throwing TypeError. (#34)
 - Support multiple value display when there are multiple points on the same x positions. (#33)
 - Rename the collisionComponents as hoverDetectionComponents to made the name more intelligible. (#33)
 

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
+  },
+  "resolutions": {
+    "ansi-styles": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "private": true,
   "scripts": {
-    "start": "docz dev",
+    "start": "yarn run clean && yarn run dev",
+    "dev": "docz dev",
     "build:doc": "docz build",
     "type-check": "lerna run type-check --parallel --stream",
     "type-check:watch": "lerna run type-check:watch --parallel --stream -- -- --preserveWatchOutput",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,11 +2294,7 @@ ansi-regex@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.0.0.tgz#70de791edf021404c3fd615aa89118ae0432e5a9"
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-
-ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^2.2.1, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:


### PR DESCRIPTION
# Purpose

Avoid VSCode keep jumping to the compiled files when clicking the "Go to Definition" on the imported modules of other libs under `/packages` by running the clean script before the dev server started.

Additionally, to prevent developers from ocassionally encountering the [strange TypeError when `docz` server started](https://github.com/pedronauck/docz/issues/536), a `resolution` of `ansi-styles` is added.

# Changes

- Clean compiled files before the docz server started
- Prevent docz from throwing TypeError 

