### PR TITLE
[Fix] Refine visual styles of the title, legend, and tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Fixed
 - Fix the typing problems raised by `@types/styled-components` and `react-spring`. (#35)
+- Fix the visual details of charts (#42):
+  - Fix the margin of bar charts with the title bar.
+  - Make the tooltips fit the size of the content.
+  - Remove the white background of the legend.
 
 ## [0.0.2]
 

--- a/docs/themes/Theme.mdx
+++ b/docs/themes/Theme.mdx
@@ -203,7 +203,7 @@ const COLORS = {
     titleDescFontSize: 15,
     titleDescColor: COLORS.GRAY,
     lineHeight: 1.3,
-    padding: '0 1rem',
+    padding: '0.5rem 1rem',
     defaultTextAlign: 'left',
   },
 }

--- a/packages/chart/src/bar/BarChart.tsx
+++ b/packages/chart/src/bar/BarChart.tsx
@@ -86,7 +86,8 @@ export const BarChart = ({
     legendRef,
     outerDimension,
     graphDimension,
-  } = useChartDimensions(margin);
+    graphMargin,
+  } = useChartDimensions(margin, color);
   const { width: graphWidth, height: graphHeight } = graphDimension;
 
   /**
@@ -266,7 +267,7 @@ export const BarChart = ({
       drawFromXAxis={drawFromXAxis}
       // put the axes on top of the bars
       axisInBackground={false}
-      margin={margin}
+      margin={graphMargin}
       data={data}
       scalesConfig={scalesConfig}
       svgOverlay={

--- a/packages/graph/src/legend/LegendGroup.tsx
+++ b/packages/graph/src/legend/LegendGroup.tsx
@@ -10,7 +10,6 @@ interface LegendGroupProps {
 }
 
 const LegendGroupWrapper = styled.div`
-  background: #fff;
   position: absolute;
 `;
 

--- a/packages/graph/src/themes/index.tsx
+++ b/packages/graph/src/themes/index.tsx
@@ -52,7 +52,7 @@ export const themes = {
       titleDescFontSize: 15,
       titleDescColor: COLORS.GRAY,
       lineHeight: 1.3,
-      padding: '0 1rem',
+      padding: '0.5rem 1rem',
       defaultTextAlign: 'left',
     },
   },

--- a/packages/graph/src/tooltip/Tooltip.tsx
+++ b/packages/graph/src/tooltip/Tooltip.tsx
@@ -15,6 +15,7 @@ export interface TooltipProps {
 }
 
 const TooltipWrapper = styled.div`
+  display: table;
   position: absolute;
   min-width: 3rem;
   background-color: rgba(255, 255, 255, 0.8);


### PR DESCRIPTION
# Purpose

Refine the following visual details of a chart:

**Title**: Fix the graph margin for the bar charts with the title bar.
![compare_title](https://user-images.githubusercontent.com/1139698/62355202-2339c100-b541-11e9-90f3-1656f567c276.jpg)


**Tooltip**: Fit the size of its content

![compare_tooltip](https://user-images.githubusercontent.com/1139698/62354423-672bc680-b53f-11e9-8fa6-10cfb844e6bd.jpg)

**Legend**: Remove the white background of the legend for charts with different background colors

![compare_legend](https://user-images.githubusercontent.com/1139698/62354741-22ecf600-b540-11e9-99ac-17675e1888c1.jpg)

Note that the online docz has also been updated.

# Changes

- Fix the margin of bar charts with the title bar
- Make the tooltips fit the size of the content
- Remove the white background of the legend
